### PR TITLE
Change logging formatting to lazily evaluate (performance critical)

### DIFF
--- a/presto/client.py
+++ b/presto/client.py
@@ -349,9 +349,10 @@ class PrestoRequest(object):
                 location = http_response.headers["Location"]
                 url = self._redirect_handler.handle(location)
                 logger.info(
-                    "redirect {} from {} to {}".format(
-                        http_response.status_code, location, url
-                    )
+                    "redirect {} from {} to {}",
+                    http_response.status_code,
+                    location, 
+                    url
                 )
                 http_response = self._post(
                     url,
@@ -401,7 +402,9 @@ class PrestoRequest(object):
 
         http_response.encoding = "utf-8"
         response = http_response.json()
-        logger.debug("HTTP {}: {}".format(http_response.status_code, response))
+        logger.debug("HTTP {status_code}: {response}", 
+                     status_code=http_response.status_code, 
+                     response=response)
         if "error" in response:
             raise self._process_error(response["error"], response.get("id"))
 
@@ -460,7 +463,7 @@ class PrestoResult(object):
             rows = self._query.fetch()
             for row in rows:
                 self._rownumber += 1
-                logger.debug("row {}".format(row))
+                logger.debug("row {}", row)
                 yield row
 
     @property
@@ -551,11 +554,11 @@ class PrestoQuery(object):
 
         self._cancelled = True
         url = self._request.get_url("/v1/query/{}".format(self.query_id))
-        logger.debug("cancelling query: %s", self.query_id)
+        logger.debug("cancelling query: {query_id}", query_id=self.query_id)
         response = self._request.delete(url)
         logger.info(response)
         if response.status_code == requests.codes.no_content:
-            logger.debug("query cancelled: %s", self.query_id)
+            logger.debug("query cancelled: {query_id}", query_id=self.query_id)
             return
         self._request.raise_response_error(response)
 

--- a/presto/exceptions.py
+++ b/presto/exceptions.py
@@ -126,7 +126,7 @@ def retry_with(handle_retry, exceptions, conditions, max_attempts):
                         handle_retry.retry(func, args, kwargs, err, attempt)
                         continue
                     break
-            logger.info("failed after {} attempts".format(attempt))
+            logger.info("failed after {} attempts", attempt)
             if error is not None:
                 raise error
             return result

--- a/presto/logging.py
+++ b/presto/logging.py
@@ -14,12 +14,63 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
+import inspect
+import string
 
 LEVEL = logging.INFO
 
+class LoggingFormatError(Exception):
+    """
+    Raise this exception when the logging adapter is unable to
+    deduce whether arguments are meant for formatting or for the logger itself.
+    """
+
+class LogMessage:
+    def __init__(self, fmt, args, kwargs):
+        self.fmt = fmt
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self):
+        return str(self.fmt).format(*self.args, **self.kwargs)
+
+    @property
+    def keywords(self):
+        return 
+
+class FormatLogger(logging.LoggerAdapter):
+    def __init__(self, logger, extra=None):
+        super(FormatLogger, self).__init__(logger, extra or {})
+
+        # The keywords may be different per instance of FormatLogger depending 
+        # on whether this logger is derived and _log is overridden.
+        sig = inspect.signature(self.logger._log)
+        self.logger_keywords = set(p.name for p in sig.parameters.values() if p.default != inspect.Parameter.empty)
+    
+    def filter_kwargs(self, msg, kwargs):
+        msg_keywords = set(fname for _, fname, _, _ in string.Formatter().parse(msg) if fname)
+
+        ambiguous_parameters = self.logger_keywords & msg_keywords
+        if ambiguous_parameters:
+            raise LoggingFormatError("Ambiguous parameters {} used during logging.".format(ambiguous_parameters))
+
+        logger_kwargs = {}
+        msg_kwargs = {}
+        for name, val in kwargs.items():
+            if name in logger_kwargs:
+                logger_kwargs[name] = val
+            else:
+                msg_kwargs[name] = val
+        return logger_kwargs, msg_kwargs
+
+    def log(self, level, msg, *args, **kwargs):
+        if self.isEnabledFor(level):
+            msg, kwargs = self.process(msg, kwargs)
+            logger_kwargs, msg_kwargs = self.filter_kwargs(msg, kwargs)
+            self.logger._log(level, LogMessage(msg, args, msg_kwargs), tuple(), **logger_kwargs)
 
 # TODO: provide interface to use ``logging.dictConfig``
 def get_logger(name, log_level=LEVEL):
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
-    return logger
+    return FormatLogger(logger)

--- a/presto/logging.py
+++ b/presto/logging.py
@@ -27,12 +27,13 @@ class LoggingFormatError(Exception):
 
 class LogMessage:
     def __init__(self, fmt, args, kwargs):
+        # fmt is assumed to be str, performed in FormatLogger.log()
         self.fmt = fmt
         self.args = args
         self.kwargs = kwargs
 
     def __str__(self):
-        return str(self.fmt).format(*self.args, **self.kwargs)
+        return self.fmt.format(*self.args, **self.kwargs)
 
     @property
     def keywords(self):
@@ -65,6 +66,7 @@ class FormatLogger(logging.LoggerAdapter):
 
     def log(self, level, msg, *args, **kwargs):
         if self.isEnabledFor(level):
+            msg = str(msg)
             msg, kwargs = self.process(msg, kwargs)
             logger_kwargs, msg_kwargs = self.filter_kwargs(msg, kwargs)
             self.logger._log(level, LogMessage(msg, args, msg_kwargs), tuple(), **logger_kwargs)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import logging
+import presto.logging
+
+def test_log_no_args(caplog):
+    with caplog.at_level(logging.DEBUG):
+        logger = presto.logging.get_logger(__name__, log_level=logging.DEBUG)
+        logger.debug("hello")
+        logger.info("there")
+
+    assert len(caplog.records) == 2
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert caplog.records[1].levelno == logging.INFO
+    assert caplog.records[0].message == "hello"
+    assert caplog.records[1].message == "there"
+
+def test_log_args(caplog):
+    with caplog.at_level(logging.DEBUG):
+        logger = presto.logging.get_logger(__name__, log_level=logging.DEBUG)
+        logger.debug("args: {} {} {}", 1, 2, 3)
+        logger.info("ordered: {2} {1} {0}", 1, 2, 3)
+
+    assert len(caplog.records) == 2
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert caplog.records[1].levelno == logging.INFO
+    assert caplog.records[0].message == "args: 1 2 3"
+    assert caplog.records[1].message == "ordered: 3 2 1"
+    
+def test_log_kwargs(caplog):
+    with caplog.at_level(logging.DEBUG):
+        logger = presto.logging.get_logger(__name__, log_level=logging.DEBUG)
+        logger.debug("kwargs: {a} {b} {c}", c=2, b=1, a=3)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert caplog.records[0].message == "kwargs: 3 1 2"
+
+def test_log_conflict_kwargs():
+    with pytest.raises(presto.logging.LoggingFormatError):
+        logger = presto.logging.get_logger(__name__, log_level=logging.DEBUG)
+        logger.debug("kwargs: {stack_info}", stack_info=5)
+    


### PR DESCRIPTION
When comparing `presto-python-client` with `pyhive` for performance reasons, I found this client to run extremely slow for queries with large throughput. Running `line_profiler` on `fetchall()`, we see this:

```
Total time: 42.8376 s
dbapi.py
Function: fetchall at line 470

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   470                                               def fetchall(self):
   471                                                   # type: () -> List[List[Any]]
   472         1   42837588.0 42837588.0    100.0          return list(self.genall())
   
Total time: 14.4723 s
client.py
Function: process at line 397

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   397                                               def process(self, http_response):
...
   402       313        336.0      1.1      0.0          http_response.encoding = "utf-8"
   403       313    7311835.0  23360.5     50.5          response = http_response.json()
   404       313    7147288.0  22834.8     49.4          logger.debug("HTTP {}: {}".format(http_response.status_code, response))
   405       313        551.0      1.8      0.0          if "error" in response:
...
   428       313        296.0      0.9      0.0              rows=response.get("data", []),
   429       313        281.0      0.9      0.0              columns=response.get("columns"),
   430                                                   )

Total time: 42.4591 s
client.py
Function: __iter__ at line 451

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   451                                               def __iter__(self):
...
   458                                                   # Subsequent fetches from GET requests until next_uri is empty.
   459       314        880.0      2.8      0.0          while not self._query.is_finished():
   460       313   35453558.0 113270.2     83.5              rows = self._query.fetch()
   461    160313      68578.0      0.4      0.2              for row in rows:
   462    160000      90325.0      0.6      0.2                  self._rownumber += 1
   463    160000    6775992.0     42.3     16.0                  logger.debug("row {}".format(row))
   464    160000      69789.0      0.4      0.2                  yield row

Total time: 35.4451 s
client.py
Function: fetch at line 532

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   532                                               def fetch(self):
   533                                                   # type: () -> List[List[Any]]
   534                                                   """Continue fetching data for the current query_id"""
   535       313   20928528.0  66864.3     59.0          response = self._request.get(self._request.next_uri)
   536       313   14479264.0  46259.6     40.8          status = self._request.process(response)
   537       313        252.0      0.8      0.0          if status.columns:
...
```

Zooming into two lines:

```
   404       313    7147288.0  22834.8     49.4          logger.debug("HTTP {}: {}".format(http_response.status_code, response))
   463    160000    6775992.0     42.3     16.0                  logger.debug("row {}".format(row))
```

We see that although our `LEVEL` is set to `INFO`, the formatting on these strings are done eagerly and then discarded. The formatting itself takes a whole **7 seconds and 6 seconds respectively** out of 43 seconds. For context, Pyhive takes roughly 28 seconds. The exact setup to reproduce this benchmark is redacted, but a comparable benchmark could be running `SELECT * FROM some_big_table` from a localhost coordinator. We would love to use this presto client in our production workflow but with the performance issue here we have decided not to consider it until a fix has been applied.

To do this, people typically use `logging.info("%s", x)` syntax. However, [the official python docs don't encourage this style](https://docs.python.org/3/library/stdtypes.html?highlight=sprintf#printf-style-string-formatting). So how can we use `logging.info("{}", x)`, preserving our original logs and formatting style? The change here is a common one - the logging library provides a [LoggerAdapter](https://docs.python.org/3/library/logging.html#loggeradapter-objects) class that allow us to return a "logger" of the same API but perform python3 formatting style only if the level is appropriate (lazily evaluated). For example, see [the official python cookbook](https://docs.python.org/3/howto/logging-cookbook.html#use-of-alternative-formatting-styles).