### PR TITLE
Complete transition to Trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-[![Build Status](https://github.com/prestosql/presto-python-client/workflows/ci/badge.svg)](https://github.com/prestosql/presto-python-client/actions?query=workflow%3Aci+event%3Apush+branch%3Amaster)
-[![Presto Slack](https://img.shields.io/static/v1?logo=slack&logoColor=959DA5&label=Slack&labelColor=333a41&message=join%20conversation&color=3AC358)](https://prestosql.io/slack.html)
+[![Build Status](https://github.com/trinodb/trino-python-client/workflows/ci/badge.svg)](https://github.com/trinodb/trino-python-client/actions?query=workflow%3Aci+event%3Apush+branch%3Amaster)
+[![Trino Slack](https://img.shields.io/static/v1?logo=slack&logoColor=959DA5&label=Slack&labelColor=333a41&message=join%20conversation&color=3AC358)](https://trino.io/slack.html)
 [![Presto: The Definitive Guide book download](https://img.shields.io/badge/Presto%3A%20The%20Definitive%20Guide-download-brightgreen)](https://www.starburstdata.com/oreilly-presto-guide-download/)
 
 # Introduction
 
-This package provides a client interface to query [Presto](https://prestosql.io/)
+This package provides a client interface to query [Trino](https://trino.io/)
 a distributed SQL engine. It supports Python 2.7, 3.5, 3.6, and pypy.
 
 # Installation
 
 ```
-$ pip install presto-client
+$ pip install trino
 ```
 
 # Quick Start
 
-Use the DBAPI interface to query Presto:
+Use the DBAPI interface to query Trino:
 
 ```python
 import trino
@@ -32,15 +32,15 @@ rows = cur.fetchall()
 ```
 
 This will query the `system.runtime.nodes` system tables that shows the nodes
-in the Presto cluster.
+in the Trino cluster.
 
-The DBAPI implementation in `presto.dbapi` provides methods to retrieve fewer
+The DBAPI implementation in `trino.dbapi` provides methods to retrieve fewer
 rows for example `Cursorfetchone()` or `Cursor.fetchmany()`. By default
 `Cursor.fetchmany()` fetches one row. Please set
-`presto.dbapi.Cursor.arraysize` accordingly.
+`trino.dbapi.Cursor.arraysize` accordingly.
 
 # Basic Authentication
-The `BasicAuthentication` class can be used to connect to a LDAP-configured Presto
+The `BasicAuthentication` class can be used to connect to a LDAP-configured Trino
 cluster:
 ```python
 import trino
@@ -81,9 +81,9 @@ with trino.dbapi.connect(
 ```
 
 The transaction is created when the first SQL statement is executed.
-`presto.dbapi.Connection.commit()` will be automatically called when the code
+`trino.dbapi.Connection.commit()` will be automatically called when the code
 exits the *with* context and the queries succeed, otherwise
-`presto.dbapi.Connection.rollback()' will be called.
+`trino.dbapi.Connection.rollback()' will be called.
 
 # Development
 
@@ -126,7 +126,7 @@ When the code is ready, submit a Pull Request.
 There is a helper scripts, `run`, that provides commands to run tests.
 Type `./run tests` to run both unit and integration tests.
 
-`presto-python-client` uses [pytest](https://pytest.org/) for its tests. To run
+`trino-python-client` uses [pytest](https://pytest.org/) for its tests. To run
 only unit tests, type:
 
 ```
@@ -148,9 +148,9 @@ To run integration tests:
 $ pytest integration_tests
 ```
 
-They pull a Docker image and then run a container with a Presto server:
-- the image is named `prestosql/presto:${PRESTO_VERSION}`
-- the container is named `presto-python-client-tests-{uuid4()[:7]}`
+They pull a Docker image and then run a container with a Trino server:
+- the image is named `trinodb/trino:${TRINO_VERSION}`
+- the container is named `trino-python-client-tests-{uuid4()[:7]}`
 
 ## Releasing
 
@@ -175,5 +175,5 @@ They pull a Docker image and then run a container with a Presto server:
 Feel free to create an issue as it make your request visible to other users and contributors.
 
 If an interactive discussion would be better or if you just want to hangout and chat about
-the Presto Python client, you can join us on the *#python-client* channel on
-[Presto Slack](https://prestosql.io/slack.html).
+the Trino Python client, you can join us on the *#python-client* channel on
+[Trino Slack](https://trino.io/slack.html).

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,7 +26,7 @@ except ImportError:
     import mock
 
 from requests_kerberos.exceptions import KerberosExchangeError
-from trino.client import PROXIES, PrestoQuery, PrestoRequest, PrestoResult
+from trino.client import PROXIES, TrinoQuery, TrinoRequest, TrinoResult
 from trino.auth import KerberosAuthentication
 from trino import constants
 import trino.exceptions
@@ -34,11 +34,11 @@ import trino.exceptions
 
 """
 This is the response to the first HTTP request (a POST) from an actual
-Presto session. It is deliberately not truncated to document such response
+Trino session. It is deliberately not truncated to document such response
 and allow to use it for other tests.
 To get some HTTP response, set logging level to DEBUG with
 ``logging.basicConfig(level=logging.DEBUG)`` or
-``presto.client.logger.setLevel(logging.DEBUG)``.
+``trino.client.logger.setLevel(logging.DEBUG)``.
 
 ::
     from trino import dbapi
@@ -75,7 +75,7 @@ RESP_DATA_POST_0 = {
 
 """
 This is the response to the second HTTP request (a GET) from an actual
-Presto session. It is deliberately not truncated to document such response
+Trino session. It is deliberately not truncated to document such response
 and allow to use it for other tests. After doing the steps above, do:
 
 ::
@@ -270,10 +270,10 @@ def get_json_get_error_0(self):
     return RESP_ERROR_GET_0
 
 
-def test_presto_initial_request(monkeypatch):
-    monkeypatch.setattr(PrestoRequest.http.Response, "json", get_json_post_0)
+def test_trino_initial_request(monkeypatch):
+    monkeypatch.setattr(TrinoRequest.http.Response, "json", get_json_post_0)
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -284,7 +284,7 @@ def test_presto_initial_request(monkeypatch):
         session_properties={},
     )
 
-    http_resp = PrestoRequest.http.Response()
+    http_resp = TrinoRequest.http.Response()
     http_resp.status_code = 200
     status = req.process(http_resp)
 
@@ -307,10 +307,10 @@ class ArgumentsRecorder(object):
 
 def test_request_headers(monkeypatch):
     post_recorder = ArgumentsRecorder()
-    monkeypatch.setattr(PrestoRequest.http.Session, "post", post_recorder)
+    monkeypatch.setattr(TrinoRequest.http.Session, "post", post_recorder)
 
     get_recorder = ArgumentsRecorder()
-    monkeypatch.setattr(PrestoRequest.http.Session, "get", get_recorder)
+    monkeypatch.setattr(TrinoRequest.http.Session, "get", get_recorder)
 
     catalog = "test_catalog"
     schema = "test_schema"
@@ -321,7 +321,7 @@ def test_request_headers(monkeypatch):
     client_info_header = constants.HEADER_CLIENT_INFO
     client_info_value = "some_client_info"
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user=user,
@@ -356,13 +356,13 @@ def test_request_headers(monkeypatch):
 
 def test_additional_request_post_headers(monkeypatch):
     """
-    Tests that the `PrestoRequest.post` function can take addtional headers
+    Tests that the `TrinoRequest.post` function can take addtional headers
     and that it combines them with the existing ones to perform the request.
     """
     post_recorder = ArgumentsRecorder()
-    monkeypatch.setattr(PrestoRequest.http.Session, "post", post_recorder)
+    monkeypatch.setattr(TrinoRequest.http.Session, "post", post_recorder)
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -375,8 +375,8 @@ def test_additional_request_post_headers(monkeypatch):
 
     sql = 'select 1'
     additional_headers = {
-        'X-Presto-Fake-1': 'one',
-        'X-Presto-Fake-2': 'two',
+        'X-Trino-Fake-1': 'one',
+        'X-Trino-Fake-2': 'two',
     }
 
     combined_headers = req.http_headers
@@ -390,7 +390,7 @@ def test_additional_request_post_headers(monkeypatch):
 
 def test_request_invalid_http_headers():
     with pytest.raises(ValueError) as value_error:
-        PrestoRequest(
+        TrinoRequest(
             host="coordinator",
             port=8080,
             user="test",
@@ -416,7 +416,7 @@ def test_request_timeout():
 
     # timeout without retry
     for request_timeout in [timeout, (timeout, timeout)]:
-        req = PrestoRequest(
+        req = TrinoRequest(
             host=host,
             port=port,
             user="test",
@@ -435,10 +435,10 @@ def test_request_timeout():
     httpretty.reset()
 
 
-def test_presto_fetch_request(monkeypatch):
-    monkeypatch.setattr(PrestoRequest.http.Response, "json", get_json_get_0)
+def test_trino_fetch_request(monkeypatch):
+    monkeypatch.setattr(TrinoRequest.http.Response, "json", get_json_get_0)
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -449,7 +449,7 @@ def test_presto_fetch_request(monkeypatch):
         session_properties={},
     )
 
-    http_resp = PrestoRequest.http.Response()
+    http_resp = TrinoRequest.http.Response()
     http_resp.status_code = 200
     status = req.process(http_resp)
 
@@ -458,10 +458,10 @@ def test_presto_fetch_request(monkeypatch):
     assert status.rows == RESP_DATA_GET_0["data"]
 
 
-def test_presto_fetch_error(monkeypatch):
-    monkeypatch.setattr(PrestoRequest.http.Response, "json", get_json_get_error_0)
+def test_trino_fetch_error(monkeypatch):
+    monkeypatch.setattr(TrinoRequest.http.Response, "json", get_json_get_error_0)
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -472,9 +472,9 @@ def test_presto_fetch_error(monkeypatch):
         session_properties={},
     )
 
-    http_resp = PrestoRequest.http.Response()
+    http_resp = TrinoRequest.http.Response()
     http_resp.status_code = 200
-    with pytest.raises(trino.exceptions.PrestoUserError) as exception_info:
+    with pytest.raises(trino.exceptions.TrinoUserError) as exception_info:
         req.process(http_resp)
     error = exception_info.value
     assert error.error_code == 1
@@ -499,10 +499,10 @@ def test_presto_fetch_error(monkeypatch):
         (404, trino.exceptions.HttpError, "error 404"),
     ],
 )
-def test_presto_connection_error(monkeypatch, error_code, error_type, error_message):
-    monkeypatch.setattr(PrestoRequest.http.Response, "json", lambda x: {})
+def test_trino_connection_error(monkeypatch, error_code, error_type, error_message):
+    monkeypatch.setattr(TrinoRequest.http.Response, "json", lambda x: {})
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -513,7 +513,7 @@ def test_presto_connection_error(monkeypatch, error_code, error_type, error_mess
         session_properties={},
     )
 
-    http_resp = PrestoRequest.http.Response()
+    http_resp = TrinoRequest.http.Response()
     http_resp.status_code = error_code
     with pytest.raises(error_type) as error:
         req.process(http_resp)
@@ -541,14 +541,14 @@ class RetryRecorder(object):
 
 def test_authentication_fail_retry(monkeypatch):
     post_retry = RetryRecorder(error=KerberosExchangeError())
-    monkeypatch.setattr(PrestoRequest.http.Session, "post", post_retry)
+    monkeypatch.setattr(TrinoRequest.http.Session, "post", post_retry)
 
     get_retry = RetryRecorder(error=KerberosExchangeError())
-    monkeypatch.setattr(PrestoRequest.http.Session, "get", get_retry)
+    monkeypatch.setattr(TrinoRequest.http.Session, "get", get_retry)
 
     attempts = 3
     kerberos_auth = KerberosAuthentication()
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -567,17 +567,17 @@ def test_authentication_fail_retry(monkeypatch):
 
 
 def test_503_error_retry(monkeypatch):
-    http_resp = PrestoRequest.http.Response()
+    http_resp = TrinoRequest.http.Response()
     http_resp.status_code = 503
 
     post_retry = RetryRecorder(result=http_resp)
-    monkeypatch.setattr(PrestoRequest.http.Session, "post", post_retry)
+    monkeypatch.setattr(TrinoRequest.http.Session, "post", post_retry)
 
     get_retry = RetryRecorder(result=http_resp)
-    monkeypatch.setattr(PrestoRequest.http.Session, "get", get_retry)
+    monkeypatch.setattr(TrinoRequest.http.Session, "get", get_retry)
 
     attempts = 3
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator", port=8080, user="test", max_attempts=attempts
     )
 
@@ -599,49 +599,49 @@ class FakeGatewayResponse(object):
         self.count += 1
         if self.count == self.redirect_count:
             return self.http_response
-        http_response = PrestoRequest.http.Response()
+        http_response = TrinoRequest.http.Response()
         http_response.status_code = 301
         http_response.headers["Location"] = "http://1.2.3.4:8080/new-path/"
         assert http_response.is_redirect
         return http_response
 
 
-def test_presto_result_response_headers():
+def test_trino_result_response_headers():
     """
-    Validates that the `PrestoResult.response_headers` property returns the
-    headers associated to the PrestoQuery instance provided to the `PrestoResult`
+    Validates that the `TrinoResult.response_headers` property returns the
+    headers associated to the TrinoQuery instance provided to the `TrinoResult`
     class.
     """
-    mock_presto_query = mock.Mock(respone_headers={
-        'X-Presto-Fake-1': 'one',
-        'X-Presto-Fake-2': 'two',
+    mock_trino_query = mock.Mock(respone_headers={
+        'X-Trino-Fake-1': 'one',
+        'X-Trino-Fake-2': 'two',
     })
 
-    result = PrestoResult(
-        query=mock_presto_query,
+    result = TrinoResult(
+        query=mock_trino_query,
     )
-    assert result.response_headers == mock_presto_query.response_headers
+    assert result.response_headers == mock_trino_query.response_headers
 
 
-def test_presto_query_response_headers():
+def test_trino_query_response_headers():
     """
-    Validates that the `PrestoQuery.execute` function can take addtional headers
+    Validates that the `TrinoQuery.execute` function can take addtional headers
     that are pass the the provided request instance post function call and it
-    returns a `PrestoResult` instance.
+    returns a `TrinoResult` instance.
     """
     class MockResponse(mock.Mock):
         # Fake response class
         @property
         def headers(self):
             return {
-                'X-Presto-Fake-1': 'one',
-                'X-Presto-Fake-2': 'two',
+                'X-Trino-Fake-1': 'one',
+                'X-Trino-Fake-2': 'two',
             }
 
         def json(self):
             return get_json_post_0(self)
 
-    req = PrestoRequest(
+    req = TrinoRequest(
         host="coordinator",
         port=8080,
         user="test",
@@ -661,7 +661,7 @@ def test_presto_query_response_headers():
     # validate that the function was called with the right arguments.
     with mock.patch.object(req, 'post', return_value=MockResponse()) as mock_post:
 
-        query = PrestoQuery(
+        query = TrinoQuery(
             request=req,
             sql=sql
         )
@@ -670,6 +670,6 @@ def test_presto_query_response_headers():
         # Validate the the post function was called with the right argguments
         mock_post.assert_called_once_with(sql, additional_headers)
 
-        # Validate the result is an instance of PrestoResult
-        assert isinstance(result, PrestoResult)
+        # Validate the result is an instance of TrinoResult
+        assert isinstance(result, TrinoResult)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 """
 
-This module defines exceptions for Presto operations. It follows the structure
+This module defines exceptions for Trino operations. It follows the structure
 defined in pep-0249.
 """
 

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -89,9 +89,9 @@ class KerberosAuthentication(Authentication):
             http_session.verify = self._ca_bundle
         return http_session
 
-    def setup(self, presto_client):
-        self.set_client_session(presto_client.client_session)
-        self.set_http_session(presto_client.http_session)
+    def setup(self, trino_client):
+        self.set_client_session(trino_client.client_session)
+        self.set_http_session(trino_client.http_session)
 
     def get_exceptions(self):
         try:
@@ -122,9 +122,9 @@ class BasicAuthentication(Authentication):
         http_session.auth = requests.auth.HTTPBasicAuth(self._username, self._password)
         return http_session
 
-    def setup(self, presto_client):
-        self.set_client_session(presto_client.client_session)
-        self.set_http_session(presto_client.http_session)
+    def setup(self, trino_client):
+        self.set_client_session(trino_client.client_session)
+        self.set_http_session(trino_client.http_session)
 
     def get_exceptions(self):
         return ()

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -17,7 +17,7 @@ from typing import Any, Optional, Text  # NOQA: mypy types
 
 
 DEFAULT_PORT = 8080
-DEFAULT_SOURCE = "presto-python-client"
+DEFAULT_SOURCE = "trino-python-client"
 DEFAULT_CATALOG = None  # type: Optional[Text]
 DEFAULT_SCHEMA = None  # type: Optional[Text]
 DEFAULT_AUTH = None  # type: Optional[Any]
@@ -29,19 +29,19 @@ HTTPS = "https"
 
 URL_STATEMENT_PATH = "/v1/statement"
 
-HEADER_CATALOG = "X-Presto-Catalog"
-HEADER_SCHEMA = "X-Presto-Schema"
-HEADER_SOURCE = "X-Presto-Source"
-HEADER_USER = "X-Presto-User"
-HEADER_CLIENT_INFO = "X-Presto-Client-Info"
+HEADER_CATALOG = "X-Trino-Catalog"
+HEADER_SCHEMA = "X-Trino-Schema"
+HEADER_SOURCE = "X-Trino-Source"
+HEADER_USER = "X-Trino-User"
+HEADER_CLIENT_INFO = "X-Trino-Client-Info"
 
-HEADER_SESSION = "X-Presto-Session"
-HEADER_SET_SESSION = "X-Presto-Set-Session"
-HEADER_CLEAR_SESSION = "X-Presto-Clear-Session"
+HEADER_SESSION = "X-Trino-Session"
+HEADER_SET_SESSION = "X-Trino-Set-Session"
+HEADER_CLEAR_SESSION = "X-Trino-Clear-Session"
 
-HEADER_STARTED_TRANSACTION = "X-Presto-Started-Transaction-Id"
-HEADER_TRANSACTION = "X-Presto-Transaction-Id"
+HEADER_STARTED_TRANSACTION = "X-Trino-Started-Transaction-Id"
+HEADER_TRANSACTION = "X-Trino-Transaction-Id"
 
-HEADER_PREPARED_STATEMENT = 'X-Presto-Prepared-Statement'
-HEADER_ADDED_PREPARE = 'X-Presto-Added-Prepare'
-HEADER_DEALLOCATED_PREPARE = 'X-Presto-Deallocated-Prepare'
+HEADER_PREPARED_STATEMENT = 'X-Trino-Prepared-Statement'
+HEADER_ADDED_PREPARE = 'X-Trino-Added-Prepare'
+HEADER_DEALLOCATED_PREPARE = 'X-Trino-Deallocated-Prepare'

--- a/trino/exceptions.py
+++ b/trino/exceptions.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 """
 
-This module defines exceptions for Presto operations. It follows the structure
+This module defines exceptions for Trino operations. It follows the structure
 defined in pep-0249.
 """
 
@@ -36,7 +36,7 @@ class Http503Error(HttpError):
     pass
 
 
-class PrestoError(Exception):
+class TrinoError(Exception):
     pass
 
 
@@ -44,7 +44,7 @@ class TimeoutError(Exception):
     pass
 
 
-class PrestoQueryError(Exception):
+class TrinoQueryError(Exception):
     def __init__(self, error, query_id=None):
         self._error = error
         self._query_id = query_id
@@ -71,7 +71,7 @@ class PrestoQueryError(Exception):
 
     @property
     def message(self):
-        return self._error.get("message", "Presto did no return an error message")
+        return self._error.get("message", "Trino did no return an error message")
 
     @property
     def error_location(self):
@@ -95,15 +95,15 @@ class PrestoQueryError(Exception):
         return repr(self)
 
 
-class PrestoExternalError(PrestoQueryError):
+class TrinoExternalError(TrinoQueryError):
     pass
 
 
-class PrestoInternalError(PrestoQueryError):
+class TrinoInternalError(TrinoQueryError):
     pass
 
 
-class PrestoUserError(PrestoQueryError):
+class TrinoUserError(TrinoQueryError):
     pass
 
 
@@ -207,7 +207,7 @@ class NotSupportedError(DatabaseError):
 
 class FailedToObtainAddedPrepareHeader(Error):
     """
-    Raise this exception when unable to find the 'X-Presto-Added-Prepare'
+    Raise this exception when unable to find the 'X-Trino-Added-Prepare'
     header in the response of a PREPARE statement request.
     """
     pass
@@ -215,7 +215,7 @@ class FailedToObtainAddedPrepareHeader(Error):
 
 class FailedToObtainDeallocatedPrepareHeader(Error):
     """
-    Raise this exception when unable to find the 'X-Presto-Deallocated-Prepare'
+    Raise this exception when unable to find the 'X-Trino-Deallocated-Prepare'
     header in the response of a DEALLOCATED statement request.
     """
     pass

--- a/trino/transaction.py
+++ b/trino/transaction.py
@@ -79,7 +79,7 @@ class Transaction(object):
         logger.info("transaction started: " + self._id)
 
     def commit(self):
-        query = trino.client.PrestoQuery(self._request, COMMIT)
+        query = trino.client.TrinoQuery(self._request, COMMIT)
         try:
             list(query.execute())
         except Exception as err:
@@ -90,7 +90,7 @@ class Transaction(object):
         self._request.transaction_id = self._id
 
     def rollback(self):
-        query = trino.client.PrestoQuery(self._request, ROLLBACK)
+        query = trino.client.TrinoQuery(self._request, ROLLBACK)
         try:
             list(query.execute())
         except Exception as err:


### PR DESCRIPTION
replaced almost every occurrence of "presto" with "trino".
README.md migrated, too -- except the Presto book link
changed default version of Trino for integration tests to 351