### PR TITLE
Drop python3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         python-version: [
           2.7,
-          3.5,
           3.6,
           3.7,
           3.8,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,pypy2
+envlist = py27,py36,py37,py38,py39,pypy2
 
 [testenv]
 extras = tests


### PR DESCRIPTION
Python 3.5 was reached end-of-life in 2020. So we can drop python3.5 support.
- https://www.python.org/downloads/release/python-3510/