### PR TITLE
Pin runs-os to Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The ubuntu-latest is assigned to ubuntu-20.04 from ubuntu-18.04 in the near future.

 Github action reports a warning message like below.
> Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816

e.g: https://github.com/trinodb/trino-python-client/actions/runs/492701210