### PR TITLE
Add support for JWT Authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ cur.execute('SELECT * FROM system.runtime.nodes')
 rows = cur.fetchall()
 ```
 
+# JWT Authentication
+The `JWTAuthentication` can be used to connect to a JWT token authentication enabled Trino cluster:
+```python
+import trino
+JWT_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.DjwRE2jZhren2Wt37t5hlVru6Myq4AhpGLiiefF69u8'
+conn = trino.dbapi.connect(
+    host='coordinator-url',
+    port=8443,
+    user='the-user',
+    catalog='the-catalog',
+    schema='the-schema',
+    http_scheme='https',
+    auth=trino.auth.JWTAuthentication(JWT_TOKEN),
+)
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchall()
+```
+
 # Transactions
 The client runs by default in *autocommit* mode. To enable transactions, set
 *isolation_level* to a value different than `IsolationLevel.AUTOCOMMIT`:


### PR DESCRIPTION
The recent version of trino has the JWT authentication method so this PR adds support for JWT authentication in `trino-python-client`. I have updated documentation in `README` as well for the usage of JWT authentication.  Please let me know if any improvement is needed.