### PR TITLE
Clean up authentication

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -41,6 +41,7 @@ import requests
 
 import trino.logging
 from trino import constants, exceptions
+from trino.auth import Authentication
 from trino.transaction import NO_TRANSACTION
 
 __all__ = ["TrinoQuery", "TrinoRequest"]
@@ -201,7 +202,7 @@ class TrinoRequest(object):
         http_headers: Optional[Dict[str, str]] = None,
         transaction_id: Optional[str] = NO_TRANSACTION,
         http_scheme: str = constants.HTTP,
-        auth: Optional[Any] = constants.DEFAULT_AUTH,
+        auth: Optional[Authentication] = constants.DEFAULT_AUTH,
         redirect_handler: Any = None,
         max_attempts: int = MAX_ATTEMPTS,
         request_timeout: Union[float, Tuple[float, float]] = constants.DEFAULT_REQUEST_TIMEOUT,

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -10,14 +10,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Optional
 
+from trino.auth import Authentication
 
 DEFAULT_PORT = 8080
 DEFAULT_SOURCE = "trino-python-client"
 DEFAULT_CATALOG: Optional[str] = None
 DEFAULT_SCHEMA: Optional[str] = None
-DEFAULT_AUTH: Optional[Any] = None
+DEFAULT_AUTH: Optional[Authentication] = None
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_REQUEST_TIMEOUT: float = 30.0
 


### PR DESCRIPTION
- Remove unused methods set_client_session, setup, handle_err/error
- Add type hints whenever possible
- Remove requests.auth import try/except in BasicAuthentication as no exception could ever happen due to it already being imported
- Add proper type hints for auth in client and constants