### PR TITLE
capture queryset as list of dictionaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ The transaction is created when the first SQL statement is executed.
 exits the *with* context and the queries succeed, otherwise
 `trino.dbapi.Connection.rollback()` will be called.
 
+# Fetch as json
+If you need to fetch your queryset as a list of dictionaries (with column names as keys) you can use the alternative for fetchall method on the cursor.
+
+```python
+import trino
+conn = trino.dbapi.connect(
+    host='localhost',
+    port=8080,
+    user='the-user',
+    catalog='the-catalog',
+    schema='the-schema',
+)
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchjson()
+```
+
+
 # Development
 
 ## Getting Started With Development
@@ -129,9 +147,21 @@ For development purpose, pip can reference the code you are modifying in a
 $ pip install -e .[tests]
 ```
 
+
 That way, you do not need to run `pip install` again to make your changes
 applied to the *virtualenv*.
 
+If you use debian or redhat linux distributions. you may need to install following to be able to install pip packages:
+
+for Debian/Ubuntu/etc:
+```
+$ sudo apt-get install gcc python-dev libkrb5-dev
+```
+
+for RHEL/CentOS/etc:
+```
+$ sudo yum install gcc python-devel krb5-devel krb5-workstation python-devel
+```
 When the code is ready, submit a Pull Request.
 
 ## Code Style

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -466,6 +466,11 @@ class Cursor(object):
     def close(self):
         self._connection.close()
 
+    def fetchjson(self):
+        columns = [col['name'] for col in self._query.columns]
+        rows = self.fetchall()
+        return [dict(zip(columns, item)) for item in rows]
+
 
 Date = datetime.date
 Time = datetime.time


### PR DESCRIPTION
I have made an issue for this matter some hours ago: [issue](https://github.com/trinodb/trino-python-client/issues/101)

I have tried to make a new method for the Cursors to fetch data and represent them as a list of dictionaries.
Each dictionary contains a row of data with the data columns as keys.

I believe that this feature is fully backward compatible and won't make a difficulty for previous users.

I also added some docs to use this method to readme file.

I would be honored to know your opinion on adding this feature to the package.