### PR TITLE
Support full Oauth2 flow for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ cur = conn.cursor()
 cur.execute('SELECT * FROM system.runtime.nodes')
 rows = cur.fetchall()
 ```
+# OAuth2 Authentication
+- It can be used for the Oauth2 enabled trino server https://trino.io/docs/current/security/oauth2.html
+- A callback to handle the redirect url can be provided via param redirect_auth_url_handler, by default it just outputs the redirect url to stdout
+```python
+import trino
+conn = trino.dbapi.connect(
+    host='coordinator-url',
+    port=8443,
+    user='the-user',
+    catalog='the-catalog',
+    schema='the-schema',
+    http_scheme='https',
+    auth=trino.auth.OAuth2Authentication(),
+)
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchall()
+```
 
 # Transactions
 The client runs by default in *autocommit* mode. To enable transactions, set

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -12,9 +12,17 @@
 
 import abc
 import os
+import json
+import time
+import threading
+import trino.logging
 
+from enum import Enum
 from typing import Optional
 from requests.auth import AuthBase
+from trino.client import exceptions, PROXIES
+
+logger = trino.logging.get_logger(__name__)
 
 
 class Authentication(metaclass=abc.ABCMeta):
@@ -22,19 +30,8 @@ class Authentication(metaclass=abc.ABCMeta):
     def set_http_session(self, http_session):
         pass
 
-    @abc.abstractmethod
-    def set_client_session(self, client_session):
-        pass
-
-    @abc.abstractmethod
-    def setup(self):
-        pass
-
     def get_exceptions(self):
         return tuple()
-
-    def handle_err(self, error):
-        pass
 
 
 class KerberosAuthentication(Authentication):
@@ -60,9 +57,6 @@ class KerberosAuthentication(Authentication):
         self._delegate = delegate
         self._ca_bundle = ca_bundle
 
-    def set_client_session(self, client_session):
-        pass
-
     def set_http_session(self, http_session):
         try:
             import requests_kerberos
@@ -85,10 +79,6 @@ class KerberosAuthentication(Authentication):
             http_session.verify = self._ca_bundle
         return http_session
 
-    def setup(self, trino_client):
-        self.set_client_session(trino_client.client_session)
-        self.set_http_session(trino_client.http_session)
-
     def get_exceptions(self):
         try:
             from requests_kerberos.exceptions import KerberosExchangeError
@@ -97,17 +87,11 @@ class KerberosAuthentication(Authentication):
         except ImportError:
             raise RuntimeError("unable to import requests_kerberos")
 
-    def handle_error(self, handle_error):
-        pass
-
 
 class BasicAuthentication(Authentication):
     def __init__(self, username, password):
         self._username = username
         self._password = password
-
-    def set_client_session(self, client_session):
-        pass
 
     def set_http_session(self, http_session):
         try:
@@ -118,15 +102,8 @@ class BasicAuthentication(Authentication):
         http_session.auth = requests.auth.HTTPBasicAuth(self._username, self._password)
         return http_session
 
-    def setup(self, trino_client):
-        self.set_client_session(trino_client.client_session)
-        self.set_http_session(trino_client.http_session)
-
     def get_exceptions(self):
         return ()
-
-    def handle_error(self, handle_error):
-        pass
 
 
 class _BearerAuth(AuthBase):
@@ -146,19 +123,129 @@ class JWTAuthentication(Authentication):
     def __init__(self, token):
         self.token = token
 
-    def set_client_session(self, client_session):
-        pass
-
     def set_http_session(self, http_session):
         http_session.auth = _BearerAuth(self.token)
         return http_session
 
-    def setup(self, trino_client):
-        self.set_client_session(trino_client.client_session)
-        self.set_http_session(trino_client.http_session)
-
     def get_exceptions(self):
         return ()
 
-    def handle_error(self, handle_error):
-        pass
+
+def handle_redirect_auth_url(auth_url):
+    print("Open the following URL in browser for the external authentication:")
+    print(auth_url)
+
+
+class _OAuth2TokenBearer(AuthBase):
+    """
+    Custom implementation of Trino Oauth2 based authorization to get the token
+    """
+    MAX_OAUTH_ATTEMPTS = 5
+
+    class _AuthStep(Enum):
+        GET_REDIRECT_SERVER = 0
+        GET_TOKEN = 1
+
+    def __init__(self, http_session, redirect_auth_url_handler=handle_redirect_auth_url):
+        self._redirect_auth_url = redirect_auth_url_handler
+        self.http_session = http_session
+        self._thread_local = threading.local()
+
+    def __call__(self, r):
+        if not hasattr(self._thread_local, 'init'):
+            self._thread_local.init = True
+            self._thread_local.token = None
+            self._thread_local.token_server = None
+            self._thread_local.attempts = 0
+            self._thread_local.auth_step = self._AuthStep.GET_REDIRECT_SERVER
+
+        if self._thread_local.token:
+            r.headers['Authorization'] = "Bearer " + self._thread_local.token
+
+        r.register_hook('response', self.__authenticate)
+
+        return r
+
+    def __authenticate(self, r, **kwargs):
+        if (self._thread_local.auth_step == self._AuthStep.GET_REDIRECT_SERVER):
+            self.__process_get_redirect_server(r)
+        elif (self._thread_local.auth_step == self._AuthStep.GET_TOKEN):
+            self.__process_get_token(r)
+        return r
+
+    def __process_get_redirect_server(self, r):
+        if not 400 <= r.status_code < 500:
+            return r
+
+        # we have to handle the authentication, may be token the token expired or it wasn't there at all
+        auth_info = r.headers.get('WWW-Authenticate')
+        if not auth_info:
+            raise exceptions.TrinoAuthError("Error: header WWW-Authenticate not available in the response.")
+
+        matches = dict((s.strip().split('=', 1) for s in auth_info.split(",")))
+        if matches is None:
+            raise exceptions.TrinoAuthError(f"Error: header info didn't match {auth_info}")
+
+        auth_server = matches.get('Bearer x_redirect_server')
+        if auth_server is None:
+            raise exceptions.TrinoAuthError("Error: header info didn't have Bearer x_redirect_server")
+
+        token_server = matches.get('x_token_server')
+        if token_server is None:
+            raise exceptions.TrinoAuthError("Error: header info didn't have x_token_server")
+
+        self._thread_local.token_server = token_server.strip('"')
+
+        # tell app that use this url to proceed with the authentication
+        self._redirect_auth_url(auth_server.strip('"'))
+
+        # go to the next step, request a token from the token server
+        self.__request_token()
+
+        return r
+
+    def __request_token(self):
+        self._thread_local.auth_step = self._AuthStep.GET_TOKEN
+        self._thread_local.attempts += 1
+
+        if self._thread_local.attempts < self.MAX_OAUTH_ATTEMPTS:
+            time.sleep(1)
+            self.http_session.get(self._thread_local.token_server, proxies=PROXIES)
+        else:
+            raise exceptions.TrinoAuthError("Exceeded max attempts while getting the token")
+
+    def __process_get_token(self, r):
+        token = None
+        if self._thread_local.attempts < self.MAX_OAUTH_ATTEMPTS:
+            response = r
+            if response.status_code == 200:
+                token_response = json.loads(response.text)
+                token = token_response.get('token')
+                if token:
+                    self._thread_local.token = token
+                    self._thread_local.attempts = 0
+                    self._thread_local.auth_step = self._AuthStep.GET_REDIRECT_SERVER
+                    return r
+                error = token_response.get('error')
+                if error:
+                    raise exceptions.TrinoAuthError(f"Error while getting the token : {error}")
+                else:
+                    token_server = token_response.get('nextUri')
+                    logger.debug(f"nextURi auth token server {token_server}")
+                    self._thread_local.token_server = token_server
+                    self.__request_token()
+            else:
+                raise exceptions.TrinoAuthError(
+                    f"Error while getting the token response status code:{response.status_code}")
+
+
+class OAuth2Authentication(Authentication):
+    def __init__(self, redirect_auth_url_handler=handle_redirect_auth_url):
+        self._redirect_auth_url = redirect_auth_url_handler
+
+    def set_http_session(self, http_session):
+        http_session.auth = _OAuth2TokenBearer(http_session, self._redirect_auth_url)
+        return http_session
+
+    def get_exceptions(self):
+        return ()

--- a/trino/client.py
+++ b/trino/client.py
@@ -44,7 +44,7 @@ import trino.logging
 from trino import constants, exceptions
 from trino.transaction import NO_TRANSACTION
 
-__all__ = ["TrinoQuery", "TrinoRequest"]
+__all__ = ["TrinoQuery", "TrinoRequest", "PROXIES"]
 
 logger = trino.logging.get_logger(__name__)
 
@@ -305,8 +305,9 @@ class TrinoRequest(object):
             exceptions=self._exceptions,
             conditions=(
                 # need retry when there is no exception but the status code is 503 or 504
+                # retry 401 for OAuth
                 lambda response: getattr(response, "status_code", None)
-                in (503, 504),
+                in (401, 503, 504),
             ),
             max_attempts=self._max_attempts,
         )

--- a/trino/exceptions.py
+++ b/trino/exceptions.py
@@ -45,6 +45,10 @@ class TimeoutError(Exception):
     pass
 
 
+class TrinoAuthError(Exception):
+    pass
+
+
 class TrinoQueryError(Exception):
     def __init__(self, error, query_id=None):
         self._error = error


### PR DESCRIPTION
Support full flow for the OAuth2 based trino server. This is similar to the trino-cli.
The application using the trino library can override to load the authentication user via browser, by default it will print it on stdout.