### PR TITLE
Add new parameter 'extra_credential'

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ The transaction is created when the first SQL statement is executed.
 exits the *with* context and the queries succeed, otherwise
 `trino.dbapi.Connection.rollback()` will be called.
 
+# Extra Credential
+
+Send [`extra credentials`](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers):
+
+```python
+import trino
+conn = trino.dbapi.connect(
+    host='localhost',
+    port=443,
+    user='the-user',
+    extra_credential=[('a.username', 'bar'), ('a.password', 'foo')],
+)
+
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchall()
+```
+
 # Development
 
 ## Getting Started With Development

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -32,6 +32,7 @@ HEADER_SCHEMA = "X-Trino-Schema"
 HEADER_SOURCE = "X-Trino-Source"
 HEADER_USER = "X-Trino-User"
 HEADER_CLIENT_INFO = "X-Trino-Client-Info"
+HEADER_EXTRA_CREDENTIAL = "X-Trino-Extra-Credential"
 
 HEADER_SESSION = "X-Trino-Session"
 HEADER_SET_SESSION = "X-Trino-Set-Session"

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -102,6 +102,7 @@ class Connection(object):
         http_headers=None,
         http_scheme=constants.HTTP,
         auth=constants.DEFAULT_AUTH,
+        extra_credential=None,
         redirect_handler=None,
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
@@ -125,6 +126,7 @@ class Connection(object):
         self.http_headers = http_headers
         self.http_scheme = http_scheme
         self.auth = auth
+        self.extra_credential = extra_credential
         self.redirect_handler = redirect_handler
         self.max_attempts = max_attempts
         self.request_timeout = request_timeout
@@ -188,6 +190,7 @@ class Connection(object):
             NO_TRANSACTION,
             self.http_scheme,
             self.auth,
+            self.extra_credential,
             self.redirect_handler,
             self.max_attempts,
             self.request_timeout,


### PR DESCRIPTION
Fixes #6

<strike>One thing I'm not sure is the key-value pair should be `key=value` (https://github.com/trinodb/trino-python-client/issues/6#issuecomment-586734438) or `key:value` (see the [JDBC parameter reference](https://trino.io/docs/current/installation/jdbc.html?highlight=extra%20credential#parameter-reference))</strike>

## Specification

quote https://github.com/trinodb/trino-python-client/pull/116#discussion_r730947560

1. extra credentials pair `k=v` are joined by `=` while pairs are chained into a single header value by separater `, ` (comma and space).
2. extra credential key must not be empty, it contains ASCII charaters only, whitespace and `=` (equal sign) are disallowed.
3. extra credential value could be empty, and is encoded into [application/x-www-form-urlencoded MIME format](https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4) to match that of Trino CLI and JDBC driver

