### PR TITLE
Reuse the same connection when getting a token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,14 @@ kerberos_require = ["requests_kerberos"]
 
 all_require = kerberos_require + []
 
-tests_require = all_require + ["httpretty", "pytest", "pytest-runner", "pytz", "click"]
+tests_require = all_require + [
+    # httpretty >= 1.1 duplicates requests in `httpretty.latest_requests`
+    # https://github.com/gabrielfalcao/HTTPretty/issues/425
+    "httpretty < 1.1",
+    "pytest",
+    "pytest-runner",
+    "pytz",
+    "click"]
 
 setup(
     name="trino",

--- a/trino/client.py
+++ b/trino/client.py
@@ -305,9 +305,8 @@ class TrinoRequest(object):
             exceptions=self._exceptions,
             conditions=(
                 # need retry when there is no exception but the status code is 503 or 504
-                # retry 401 for OAuth
                 lambda response: getattr(response, "status_code", None)
-                in (401, 503, 504),
+                in (503, 504),
             ),
             max_attempts=self._max_attempts,
         )


### PR DESCRIPTION
The benefits of this approach are:
* there's no need for retrying 401 (Unauthorized) as the same connection
  is being reused,
* the whole authentication uses the same context (PROXIES, SSL verify
  etc.) so no need for client's setup duplication.
Additionally, OAuth2 client's tests were rewritten using HTTPretty which
stubs/mocks the http layer and makes changing implementation details
easier.