### PR TITLE
Configure tests to run weekly against latest Trino

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
 
 jobs:
   checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - "master"
   pull_request:
+  workflow_call:
+    inputs:
+      trino-version:
+        description: 'Trino docker image version to test with'
+        default: '351' # first Trino release
+        required: false
+        type: string
 
 jobs:
   checks:
@@ -36,6 +43,11 @@ jobs:
           "pypy-3.6",
           "pypy-3.7",
         ]
+        trino-version: [
+          "${{ inputs.trino-version }}",
+        ]
+    env:
+      TRINO_VERSION: ${{ matrix.trino-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,15 @@
+name: nightly-ci
+
+on:
+  schedule:
+    # test once a week
+    - cron: "0 0 * * 1"
+  workflow_dispatch: # Allows to trigger workflow manually or via API
+
+jobs:
+  trino-default:
+    uses: "trinodb/trino-python-client/.github/workflows/ci.yml@master"
+  trino-latest:
+    uses: "trinodb/trino-python-client/.github/workflows/ci.yml@master"
+    with:
+      trino-version: "latest"


### PR DESCRIPTION
The client tests run against Trino 351 by default and hence any changes
introduced in future versions that break the client won't get caught.
This commits adds a new workflow that runs once a week and tests the
latest commit against the latest version and default version.