### PR TITLE
Add latest Trino version to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
 
 jobs:
   checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
       - "master"
   pull_request:
 
+# Cancel previous PR builds.
+concurrency:
+  # Cancel all workflow runs except latest within a concurrency group. This is achieved by defining a concurrency group for the PR.
+  # Non-PR builds have singleton concurrency groups.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           "pypy-3.6",
           "pypy-3.7",
         ]
+        trino-version: [
+          "351",    # first Trino version
+          "latest",
+        ]
+    env:
+      TRINO_VERSION: "${{ matrix.trino-version }}"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,7 @@ from trino.exceptions import TimeoutError
 logger = trino.logging.get_logger(__name__)
 
 
-TRINO_VERSION = os.environ.get("TRINO_VERSION") or "351"
+TRINO_VERSION = os.environ.get("TRINO_VERSION") or "latest"
 TRINO_HOST = "127.0.0.1"
 TRINO_PORT = 8080
 

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -49,7 +49,10 @@ def test_select_query(trino_connection, trino_version):
     rows = cur.fetchall()
     assert len(rows) > 0
     row = rows[0]
-    assert row[2] == trino_version
+    if trino_version == "latest":
+        assert row[2] is not None
+    else:
+        assert row[2] == trino_version
     columns = dict([desc[:2] for desc in cur.description])
     assert columns["node_id"] == "varchar"
     assert columns["http_uri"] == "varchar"


### PR DESCRIPTION
Currently we only test the client against first Trino version i.e. 351.

This means that any changes in future versions that cause the client to break aren't caught by CI.
See https://github.com/trinodb/trino-go-client/pull/28 for motivation.