### PR TITLE
Fix broken module import

### DIFF
--- a/trino/__init__.py
+++ b/trino/__init__.py
@@ -10,4 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import auth
+from . import dbapi
+from . import client
+from . import constants
+from . import exceptions
+from . import logging
+
+__all__ = ['auth', 'dbapi', 'client', 'constants', 'exceptions', 'logging']
+
 __version__ = "0.307.0"


### PR DESCRIPTION
This reverts commit f9e68da9bcf532f50aff544a13ebb54af365b329.
This change broke the README code snippets with an error like "Cannot find reference 'dbapi' in '__init__.py'.