### PR TITLE
Revert "Use more specific module imports in tests"

### DIFF
--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import pytest
 import pytz
 
-import trino.dbapi
+import trino
 from trino.exceptions import TrinoQueryError
 from trino.transaction import IsolationLevel
 


### PR DESCRIPTION
This reverts commit 3ce46fe317da1e01ad7d41970415bdab5db025fe.
The user-facing API (and documentation) is to import the trino package
instead of the specific trino.dbapi module. Integration tests should
test using the import that is documented and part of API.