### PR TITLE
Fix transaction handling in auto-commit mode

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -153,9 +153,8 @@ def run_trino():
         stop_trino(container_id, proc)
 
 
-@pytest.fixture(scope="module")
 def trino_version():
-    yield TRINO_VERSION
+    return TRINO_VERSION
 
 
 @click.group()

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -202,6 +202,8 @@ class Connection(object):
             if self.transaction is None:
                 self.start_transaction()
             request = self.transaction._request
+        elif self.transaction is not None:
+            request = self.transaction._request
         else:
             request = self._create_request()
         return Cursor(self, request)


### PR DESCRIPTION
When an explicit transaction was started in auto-commit mode, the transaction request was not correctly attached to the cursor. That caused query and transaction were executed separately. Query was executed in separate transaction and request. 

Issue #129 

Design consideration

Starting a separate transaction in auto-commit may be disabled at all. It wasn't working, until now. If user wants to manage transaction separately can use connection in other isolation level than auto-commit. 
