### PR TITLE
Add `CertificateAuthentication` class to support cert based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ cur.execute('SELECT * FROM system.runtime.nodes')
 rows = cur.fetchall()
 ```
 
+# Certificate Authentication
+- `CertificateAuthentication` class can be used to connect to Trino cluster configured with [certificate based authentication](https://trino.io/docs/current/security/certificate.html). `CertificateAuthentication` requires paths to a valid client certificate and private key.
+```python
+import trino
+conn = trino.dbapi.connect(
+    host='coordinator-url',
+    port=8443,
+    user='the-user',
+    catalog='the-catalog',
+    schema='the-schema',
+    http_scheme='https',
+    auth=trino.auth.CertificateAuthentication("/path/to/cert", "/path/to/key"),
+)
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchall()
+```
+
 # Transactions
 The client runs by default in *autocommit* mode. To enable transactions, set
 *isolation_level* to a value different than `IsolationLevel.AUTOCOMMIT`:

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -267,3 +267,21 @@ class OAuth2Authentication(Authentication):
         if not isinstance(other, OAuth2Authentication):
             return False
         return self._redirect_auth_url == other._redirect_auth_url
+
+
+class CertificateAuthentication(Authentication):
+    def __init__(self, cert, key):
+        self._cert = cert
+        self._key = key
+
+    def set_http_session(self, http_session):
+        http_session.cert = (self._cert, self._key)
+        return http_session
+
+    def get_exceptions(self):
+        return ()
+
+    def __eq__(self, other):
+        if not isinstance(other, CertificateAuthentication):
+            return False
+        return self._cert == other._cert and self._key == other._key


### PR DESCRIPTION
Add `CertificateAuthentication` class to support cert based authentication.

Re: https://github.com/trinodb/trino-python-client/issues/30