### PR TITLE
Trim CI matrix and prepare for explicit backward compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           "3.9",
           "3.10",
           "pypy-3.7",
+          "pypy-3.8",
         ]
         trino-version: [
           "351",    # first Trino version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [
+        python: [
           "3.7",
           "3.8",
           "3.9",
@@ -42,17 +42,19 @@ jobs:
           "pypy-3.7",
           "pypy-3.8",
         ]
-        trino-version: [
-          "351",    # first Trino version
+        trino: [
           "latest",
         ]
+        include:
+          # Test with older Trino versions for backward compatibility
+          - { python: "3.10", trino: "351" }  # first Trino version
     env:
-      TRINO_VERSION: "${{ matrix.trino-version }}"
+      TRINO_VERSION: "${{ matrix.trino }}"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.6",
           "3.7",
           "3.8",
           "3.9",
           "3.10",
-          "pypy-3.6",
           "pypy-3.7",
         ]
         trino-version: [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Introduction
 
 This package provides a client interface to query [Trino](https://trino.io/)
-a distributed SQL engine. It supports Python>=3.6 and pypy.
+a distributed SQL engine. It supports Python>=3.7 and pypy.
 
 # Installation
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -75,7 +74,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database :: Front-Ends",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=["requests"],
     extras_require={
         "all": all_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310
 
 [testenv]
 extras = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39
+envlist = py37,py38,py39
 
 [testenv]
 extras = tests


### PR DESCRIPTION
Existing matrix became 14 jobs long.

We don't need to test older Trino versions with every single Python version - just the latest is enough. Matrix is now 7 jobs long.