### PR TITLE
Always install pytz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("trino/__init__.py", "rb") as f:
 kerberos_require = ["requests_kerberos"]
 sqlalchemy_require = ["sqlalchemy~=1.3"]
 
-all_require = ["pytz"] + kerberos_require + sqlalchemy_require
+all_require = kerberos_require + sqlalchemy_require
 
 tests_require = all_require + [
     # httpretty >= 1.1 duplicates requests in `httpretty.latest_requests`
@@ -36,6 +36,7 @@ tests_require = all_require + [
     "httpretty < 1.1",
     "pytest",
     "pytest-runner",
+    "pytz",
     "click",
 ]
 


### PR DESCRIPTION
An alternative to https://github.com/trinodb/trino-python-client/pull/166 that fixes https://github.com/trinodb/trino-python-client/issues/165