### PR TITLE
add trino sqlalchemy source

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -20,54 +20,63 @@ class TestTrinoDialect:
         "url, expected_args, expected_kwargs",
         [
             (
-                make_url("trino://user@localhost"),
-                list(),
-                dict(host="localhost", catalog="system", user="user"),
+                    make_url("trino://user@localhost"),
+                    list(),
+                    dict(host="localhost", catalog="system", user="user"),
             ),
             (
-                make_url("trino://user@localhost:8080"),
-                list(),
-                dict(host="localhost", port=8080, catalog="system", user="user"),
+                    make_url("trino://user@localhost:8080"),
+                    list(),
+                    dict(host="localhost", port=8080, catalog="system", user="user"),
             ),
             (
-                make_url("trino://user:pass@localhost:8080"),
-                list(),
-                dict(
-                    host="localhost",
-                    port=8080,
-                    catalog="system",
-                    user="user",
-                    auth=BasicAuthentication("user", "pass"),
-                    http_scheme="https",
-                ),
+                    make_url("trino://user:pass@localhost:8080"),
+                    list(),
+                    dict(
+                        host="localhost",
+                        port=8080,
+                        catalog="system",
+                        user="user",
+                        auth=BasicAuthentication("user", "pass"),
+                        http_scheme="https",
+                    ),
+            ),
+            (
+                    make_url("trino://user@localhost:8080/hive/default?source=superset"),
+                    list(),
+                    dict(host="localhost", port=8080, user="user", catalog="hive", schema="default",
+                         source="superset"),
             ),
         ],
     )
     def test_create_connect_args(self, url: URL, expected_args: List[Any], expected_kwargs: Dict[str, Any]):
         actual_args, actual_kwargs = self.dialect.create_connect_args(url)
-
         assert actual_args == expected_args
         assert actual_kwargs == expected_kwargs
 
-    def test_create_connect_args_missing_user_when_specify_password(self):
-        url = make_url("trino://:pass@localhost")
-        with pytest.raises(ValueError, match="Username is required when specify password in connection URL"):
-            self.dialect.create_connect_args(url)
 
-    def test_create_connect_args_wrong_db_format(self):
-        url = make_url("trino://abc@localhost/catalog/schema/foobar")
-        with pytest.raises(ValueError, match="Unexpected database format catalog/schema/foobar"):
-            self.dialect.create_connect_args(url)
+def test_create_connect_args_missing_user_when_specify_password(self):
+    url = make_url("trino://:pass@localhost")
+    with pytest.raises(ValueError, match="Username is required when specify password in connection URL"):
+        self.dialect.create_connect_args(url)
 
-    def test_get_default_isolation_level(self):
-        isolation_level = self.dialect.get_default_isolation_level(mock.Mock())
-        assert isolation_level == "AUTOCOMMIT"
 
-    def test_isolation_level(self):
-        dbapi_conn = Connection(host="localhost")
+def test_create_connect_args_wrong_db_format(self):
+    url = make_url("trino://abc@localhost/catalog/schema/foobar")
+    with pytest.raises(ValueError, match="Unexpected database format catalog/schema/foobar"):
+        self.dialect.create_connect_args(url)
 
-        self.dialect.set_isolation_level(dbapi_conn, "SERIALIZABLE")
-        assert dbapi_conn._isolation_level == IsolationLevel.SERIALIZABLE
 
-        isolation_level = self.dialect.get_isolation_level(dbapi_conn)
-        assert isolation_level == "SERIALIZABLE"
+def test_get_default_isolation_level(self):
+    isolation_level = self.dialect.get_default_isolation_level(mock.Mock())
+    assert isolation_level == "AUTOCOMMIT"
+
+
+def test_isolation_level(self):
+    dbapi_conn = Connection(host="localhost")
+
+    self.dialect.set_isolation_level(dbapi_conn, "SERIALIZABLE")
+    assert dbapi_conn._isolation_level == IsolationLevel.SERIALIZABLE
+
+    isolation_level = self.dialect.get_isolation_level(dbapi_conn)
+    assert isolation_level == "SERIALIZABLE"


### PR DESCRIPTION
When we connected to trino through superset, the source could not be specified, so all queries could not be load-balanced through the presto gateway agent