### PR TITLE
Add cte_follows_insert flag to SQLAlchemy Dialect to support proper statement creation

### DIFF
--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -62,6 +62,9 @@ class TrinoDialect(DefaultDialect):
     # and tests are needed before being enabled
     supports_statement_cache = False
 
+    # Support proper ordering of CTEs in regard to an INSERT statement
+    cte_follows_insert = True
+
     @classmethod
     def dbapi(cls):
         """


### PR DESCRIPTION
This is a quick fix to add a flag to the SQLAlchemy Dialect class that supports proper `INSERT` statement compilation when using CTEs. The Trino SQL dialect expects the CTE declarations to come after the `INSERT` keyword in a `INSERT INTO ...  SELECT` statement. Fortunately, SQLAlchemy already has a flag to handle this properly, so just setting it to `True` here in the Dialect class.