### PR TITLE
Convert numeric bindings to string for sqlalchemy.sql.String columns

### DIFF
--- a/tests/unit/sqlalchemy/test_datatype_parse.py
+++ b/tests/unit/sqlalchemy/test_datatype_parse.py
@@ -12,7 +12,6 @@
 import pytest
 from sqlalchemy.sql.sqltypes import (
     CHAR,
-    VARCHAR,
     ARRAY,
     INTEGER,
     DECIMAL,
@@ -25,7 +24,8 @@ from trino.sqlalchemy.datatype import (
     MAP,
     ROW,
     TIME,
-    TIMESTAMP
+    TIMESTAMP,
+    VARCHAR
 )
 
 

--- a/trino/sqlalchemy/datatype.py
+++ b/trino/sqlalchemy/datatype.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numbers
 import re
 from typing import Iterator, List, Optional, Tuple, Type, Union, Dict, Any
 
@@ -17,6 +18,17 @@ from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.type_api import TypeEngine
 
 SQLType = Union[TypeEngine, Type[TypeEngine]]
+
+
+class VARCHAR(sqltypes.TypeDecorator):
+    impl = sqltypes.VARCHAR
+
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if isinstance(value, numbers.Number):
+            return str(value)
+        return value
 
 
 class DOUBLE(sqltypes.Float):
@@ -87,7 +99,7 @@ _type_map = {
     # === Fixed-precision ===
     "decimal": sqltypes.DECIMAL,
     # === String ===
-    "varchar": sqltypes.VARCHAR,
+    "varchar": VARCHAR,
     "char": sqltypes.CHAR,
     "varbinary": sqltypes.VARBINARY,
     "json": sqltypes.JSON,

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -18,11 +18,13 @@ from sqlalchemy import exc, sql
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
 from sqlalchemy.engine.url import URL
+from sqlalchemy.sql import sqltypes
 
 from trino import dbapi as trino_dbapi, logging
 from trino.auth import BasicAuthentication, CertificateAuthentication, JWTAuthentication
 from trino.dbapi import Cursor
 from trino.sqlalchemy import compiler, datatype, error
+from trino.sqlalchemy.datatype import VARCHAR
 
 logger = logging.get_logger(__name__)
 
@@ -63,6 +65,11 @@ class TrinoDialect(DefaultDialect):
 
     # Support proper ordering of CTEs in regard to an INSERT statement
     cte_follows_insert = True
+
+    # map sqlalchemy types to Trino dialect specific types
+    colspecs = {
+        sqltypes.String: VARCHAR
+    }
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
This PR will autoconvert numeric values to String when inserting or updating records through sqlalchemy targeting a String column.

SqlAlchemy allows to do inserts using following syntax:

```
users = sqla.Table('users',
                           metadata,
                           sqla.Column('id', sqla.Integer),
                           sqla.Column('name', sqla.String),
                           sqla.Column('fullname', sqla.String),
                           schema="test")
metadata.create_all(engine)
ins = users.insert()
conn.execute(ins, {"id": 2, "name": "wendy", "fullname": "Wendy Williams"})
```

The python types may not match the target type of the table. Some databases will autocast these values, while Trino doesn't as in following code:

```
import pandas as pd
from sqlalchemy import create_engine
engine = create_engine('trino://user@localhost:8080/memory/default')
connection = engine.connect()

data = {'col1': ['hello', 2.0, 1]}
df = pd.DataFrame(data)

df.to_sql("test_sqlalchemy",    con=connection,    schema="default",    if_exists="replace",    index=False)
```

This will generate following exception in Trino

```
io.trino.spi.TrinoException: Insert query has mismatched column types: Table: [varchar], Query: [double]
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:48)
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:43)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitInsert(StatementAnalyzer.java:574)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitInsert(StatementAnalyzer.java:445)
	at io.trino.sql.tree.Insert.accept(Insert.java:68)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:462)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:425)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:79)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:71)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:269)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:193)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:808)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:135)
	at io.trino.$gen.Trino_386____20220727_080909_2.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```