### PR TITLE
Add JSON functionality to SQLAlchemy Dialect

### DIFF
--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -206,6 +206,9 @@ class TrinoTypeCompiler(compiler.GenericTypeCompiler):
             datatype += " WITH TIME ZONE"
         return datatype
 
+    def visit_JSON(self, type_, **kw):
+        return 'JSON'
+
 
 class TrinoIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = RESERVED_WORDS

--- a/trino/sqlalchemy/datatype.py
+++ b/trino/sqlalchemy/datatype.py
@@ -9,12 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import re
 from typing import Iterator, List, Optional, Tuple, Type, Union, Dict, Any
 
 from sqlalchemy import util
 from sqlalchemy.sql import sqltypes
-from sqlalchemy.sql.type_api import TypeEngine
+from sqlalchemy.sql.type_api import TypeDecorator, TypeEngine
+from sqlalchemy.types import String
 
 SQLType = Union[TypeEngine, Type[TypeEngine]]
 
@@ -71,6 +73,19 @@ class TIMESTAMP(sqltypes.TIMESTAMP):
         self.precision = precision
 
 
+class JSON(TypeDecorator):
+    impl = String
+
+    def process_bind_param(self, value, dialect):
+        return json.dumps(value)
+
+    def process_result_value(self, value, dialect):
+        return json.loads(value)
+
+    def get_col_spec(self, **kw):
+        return 'JSON'
+
+
 # https://trino.io/docs/current/language/types.html
 _type_map = {
     # === Boolean ===
@@ -90,7 +105,7 @@ _type_map = {
     "varchar": sqltypes.VARCHAR,
     "char": sqltypes.CHAR,
     "varbinary": sqltypes.VARBINARY,
-    "json": sqltypes.JSON,
+    "json": JSON,
     # === Date and time ===
     "date": sqltypes.DATE,
     "time": TIME,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Implement the ability to reference JSON columns using SQLAlchemy. This allows JSON columns to be created in new tables, as well as writes to/reads from them using normal Python `json` module serialization/deserialization.

Originally referenced [in this issue](https://github.com/trinodb/trino-python-client/issues/194).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Add support for creating tables containing `JSON` columns and reading and writing to them with SQLAlchemy. ([#194](https://trinodb/trino-python-client/issues/194))
```
