### PR TITLE
return empty list in un-partitioned table

### DIFF
--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -238,12 +238,14 @@ class TrinoDialect(DefaultDialect):
             raise exc.NoSuchTableError(f"schema={schema}, table={table_name}")
 
         partitioned_columns = self._get_columns(connection, f"{table_name}$partitions", schema, **kw)
+        if not partitioned_columns:
+            return []
         partition_index = dict(
-            name="partition", column_names=[col["name"] for col in partitioned_columns], unique=False
+            name="partition",
+            column_names=[col["name"] for col in partitioned_columns],
+            unique=False
         )
-        return [
-            partition_index,
-        ]
+        return [partition_index]
 
     def get_sequence_names(self, connection: Connection, schema: str = None, **kw) -> List[str]:
         """Trino has no support for sequences. Returns an empty list."""


### PR DESCRIPTION
Currently, in un-partitioned table, trino driver still return a single-value list of a partition index with **empty columns**

![image](https://user-images.githubusercontent.com/6848311/184166672-2695c02d-9ed1-4586-9b54-81b994f60c2a.png)

So, it's better to **return empty list** instead.