### PR TITLE
Acknowledge reception of data in `TrinoResult`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         include:
           # Test with older Trino versions for backward compatibility
           - { python: "3.10", trino: "351" }  # first Trino version
+          # Test with Trino version that requires result set to be fully exhausted
+          - { python: "3.10", trino: "395" }
     env:
       TRINO_VERSION: "${{ matrix.trino }}"
     steps:

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -153,8 +153,8 @@ def test_execute_many_without_params(trino_connection):
     cur = trino_connection.cursor()
     cur.execute("CREATE TABLE memory.default.test_execute_many_without_param (value varchar)")
     cur.fetchall()
-    cur.executemany("INSERT INTO memory.default.test_execute_many_without_param (value) VALUES (?)", [])
     with pytest.raises(TrinoUserError) as e:
+        cur.executemany("INSERT INTO memory.default.test_execute_many_without_param (value) VALUES (?)", [])
         cur.fetchall()
     assert "Incorrect number of parameters: expected 1 but found 0" in str(e.value)
 
@@ -883,13 +883,12 @@ def test_transaction_autocommit(trino_connection_in_autocommit):
     with trino_connection_in_autocommit as connection:
         connection.start_transaction()
         cur = connection.cursor()
-        cur.execute(
-            """
-            CREATE TABLE memory.default.nation
-            AS SELECT * from tpch.tiny.nation
-            """)
-
         with pytest.raises(TrinoUserError) as transaction_error:
+            cur.execute(
+                """
+                CREATE TABLE memory.default.nation
+                AS SELECT * from tpch.tiny.nation
+                """)
             cur.fetchall()
         assert "Catalog only supports writes using autocommit: memory" \
                in str(transaction_error.value)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,10 +37,10 @@ def sample_post_response_data():
     """
 
     yield {
-        "nextUri": "coordinator:8080/v1/statement/20210817_140827_00000_arvdv/1",
+        "nextUri": "https://coordinator:8080/v1/statement/20210817_140827_00000_arvdv/1",
         "id": "20210817_140827_00000_arvdv",
         "taskDownloadUris": [],
-        "infoUri": "http://coordinator:8080/query.html?20210817_140827_00000_arvdv",
+        "infoUri": "https://coordinator:8080/query.html?20210817_140827_00000_arvdv",
         "stats": {
             "scheduled": False,
             "runningSplits": 0,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -892,9 +892,7 @@ def test_trino_result_response_headers():
         'X-Trino-Fake-2': 'two',
     })
 
-    result = TrinoResult(
-        query=mock_trino_query,
-    )
+    result = TrinoResult(query=mock_trino_query, rows=[])
     assert result.response_headers == mock_trino_query.response_headers
 
 

--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -51,7 +51,7 @@ def test_http_session_is_defaulted_when_not_specified(mock_client):
 
 
 @httprettified
-def test_token_retrieved_once_per_auth_instance(sample_post_response_data):
+def test_token_retrieved_once_per_auth_instance(sample_post_response_data, sample_get_response_data):
     token = str(uuid.uuid4())
     challenge_id = str(uuid.uuid4())
 
@@ -59,12 +59,19 @@ def test_token_retrieved_once_per_auth_instance(sample_post_response_data):
     token_server = f"{TOKEN_RESOURCE}/{challenge_id}"
 
     post_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_post_response_data)
+    get_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_get_response_data)
 
-    # bind post statement
+    # bind post statement to submit query
     httpretty.register_uri(
         method=httpretty.POST,
         uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}",
         body=post_statement_callback)
+
+    # bind get statement for result retrieval
+    httpretty.register_uri(
+        method=httpretty.GET,
+        uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}/20210817_140827_00000_arvdv/1",
+        body=get_statement_callback)
 
     # bind get token
     get_token_callback = GetTokenCallback(token_server, token)
@@ -108,7 +115,8 @@ def test_token_retrieved_once_per_auth_instance(sample_post_response_data):
 
 
 @httprettified
-def test_token_retrieved_once_when_authentication_instance_is_shared(sample_post_response_data):
+def test_token_retrieved_once_when_authentication_instance_is_shared(sample_post_response_data,
+                                                                     sample_get_response_data):
     token = str(uuid.uuid4())
     challenge_id = str(uuid.uuid4())
 
@@ -116,12 +124,19 @@ def test_token_retrieved_once_when_authentication_instance_is_shared(sample_post
     token_server = f"{TOKEN_RESOURCE}/{challenge_id}"
 
     post_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_post_response_data)
+    get_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_get_response_data)
 
-    # bind post statement
+    # bind post statement to submit query
     httpretty.register_uri(
         method=httpretty.POST,
         uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}",
         body=post_statement_callback)
+
+    # bind get statement for result retrieval
+    httpretty.register_uri(
+        method=httpretty.GET,
+        uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}/20210817_140827_00000_arvdv/1",
+        body=get_statement_callback)
 
     # bind get token
     get_token_callback = GetTokenCallback(token_server, token)
@@ -166,7 +181,7 @@ def test_token_retrieved_once_when_authentication_instance_is_shared(sample_post
 
 
 @httprettified
-def test_token_retrieved_once_when_multithreaded(sample_post_response_data):
+def test_token_retrieved_once_when_multithreaded(sample_post_response_data, sample_get_response_data):
     token = str(uuid.uuid4())
     challenge_id = str(uuid.uuid4())
 
@@ -174,12 +189,19 @@ def test_token_retrieved_once_when_multithreaded(sample_post_response_data):
     token_server = f"{TOKEN_RESOURCE}/{challenge_id}"
 
     post_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_post_response_data)
+    get_statement_callback = PostStatementCallback(redirect_server, token_server, [token], sample_get_response_data)
 
-    # bind post statement
+    # bind post statement to submit query
     httpretty.register_uri(
         method=httpretty.POST,
         uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}",
         body=post_statement_callback)
+
+    # bind get statement for result retrieval
+    httpretty.register_uri(
+        method=httpretty.GET,
+        uri=f"{SERVER_ADDRESS}:8080{constants.URL_STATEMENT_PATH}/20210817_140827_00000_arvdv/1",
+        body=get_statement_callback)
 
     # bind get token
     get_token_callback = GetTokenCallback(token_server, token)

--- a/trino/client.py
+++ b/trino/client.py
@@ -930,8 +930,7 @@ class RowMapper:
     """
     Maps a row of data given a list of mapping functions
     """
-
-    def __init__(self, columns=[]):
+    def __init__(self, columns):
         self.columns = columns
 
     def map(self, rows):

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -322,7 +322,7 @@ class Cursor(object):
             operation=operation
         )
 
-        # Send prepare statement. Copy the _request object to avoid poluting the
+        # Send prepare statement. Copy the _request object to avoid polluting the
         # one that is going to be used to execute the actual operation.
         query = trino.client.TrinoQuery(copy.deepcopy(self._request), sql=sql,
                                         experimental_python_types=self._experimental_pyton_types)

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -231,7 +231,7 @@ class TrinoDialect(DefaultDialect):
         """
         ).strip()
         res = connection.execute(sql.text(query), schema=schema, view=view_name)
-        return res.scalar()
+        return res.scalar_one_or_none()
 
     def get_indexes(self, connection: Connection, table_name: str, schema: str = None, **kw) -> List[Dict[str, Any]]:
         if not self.has_table(connection, table_name, schema):
@@ -284,7 +284,7 @@ class TrinoDialect(DefaultDialect):
                 sql.text(query),
                 catalog_name=catalog_name, schema_name=schema_name, table_name=table_name
             )
-            return dict(text=res.scalar())
+            return dict(text=res.scalar_one_or_none())
         except error.TrinoQueryError as e:
             if e.error_name in (
                 error.PERMISSION_DENIED,
@@ -326,7 +326,7 @@ class TrinoDialect(DefaultDialect):
         query = "SELECT version()"
         try:
             res = connection.execute(sql.text(query))
-            version = res.scalar()
+            version = res.scalar_one()
             return tuple([version])
         except exc.ProgrammingError as e:
             logger.debug(f"Failed to get server version: {e.orig.message}")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #232, #95

Ensures the received data is properly acknowledged by calling the next_uri. This will avoid seeing failed queries in the query log when executing scalar queries as in the following example.

```
cur.execute("SELECT VERSION()")
cur.fetchone()
cur.cancel()
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Breaking Changes

* Make the `execute` method of the cursor block until at-least one row is received.
  This means users no longer need to call `fetchone` or `fetchall` to make sure query
  actually starts executing on the Trino server. Note that results still need to be consumed
  by calling `fetchone` or `fetchall` to make sure query isn't considered idle and terminated
  on the server. ([#232](https://trinodb/trino-python-client/issues/232))
```

```markdown
* Properly propagate query failures to the client when using `fetchone`.
  ([#95](https://trinodb/trino-python-client/issues/95))
* Fix queries returning a single row from sometimes appearing as failed on the server.
  ([#220](https://trinodb/trino-python-client/issues/220))
```