### PR TITLE
Add GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+---
+name: Bug report
+description: Report a bug or an issue you've found with Trino Python client
+labels: bug
+body:
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: What do you think should have happened
+      placeholder: >
+        A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: Describe what actually happened
+      placeholder: >
+        A clear and concise description of what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: This will help us reproduce your issue
+      placeholder: >
+        In as much detail as possible, please provide steps to reproduce the issue.
+        Sample code that triggers the issue, relevant server settings, etc is all very helpful here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Log output
+      description: What do you think went wrong?
+      placeholder: >
+        If applicable, add log output to help explain your problem.
+  - type: input
+    attributes:
+      label: Operating System
+      description: What Operating System are you using?
+      placeholder: "You can get it via `cat /etc/os-release` for example"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Trino Python client version
+      description: Which version of Trino Python client are you using?
+      placeholder: "Execute `python3 -c 'import trino; print(trino.__version__)'`"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Trino Server version
+      description: Which Trino server version are you using?
+      placeholder: "Run `SELECT VERSION();` on your Trino server"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Python version
+      description: What Python version are you using?
+      placeholder: "You can get it via executing `python --version`"
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the feature.
+      options:
+        - label: Yes I am willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+---
+contact_links:
+  - name: Ask a question or get help right here
+    url: https://github.com/trinodb/trino-python-client/discussions
+    about: Ask a question or get help here on Github Discussions
+  - name: Ask a question or get help on Slack
+    url: https://trinodb.slack.com/channels/python-client
+    about: The Trino community is very active and helpful on Slack, with users and developers from all around the world.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+---
+name: Feature request
+description: Suggest an idea for Trino Python client
+labels: enhancement
+body:
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: What would you like to happen?
+      placeholder: >
+        A clear and concise description of what you want to happen
+        and what problem it would solve.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: What did you try to make it happen?
+      placeholder: >
+        A clear and concise description of any alternative solutions or features you've considered.
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the feature.
+      options:
+        - label: Yes I am willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"


### PR DESCRIPTION
Following PR improves the Create issue form in github.

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/9265503/185210956-9e8fe3e0-e73e-4f60-b570-4e6702e3d66a.png">

<img width="968" alt="image" src="https://user-images.githubusercontent.com/9265503/185210720-409dbea4-3871-4fb3-8569-538cf35d7f70.png">

<img width="964" alt="image" src="https://user-images.githubusercontent.com/9265503/185211190-df6d95aa-5cb2-48b5-8393-1789d44d5fb7.png">

the last button refers to the #python-client Trino slack channel.
