### PR TITLE
Don't automatically label issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 description: Report a bug or an issue you've found with Trino Python client
-labels: bug
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 description: Suggest an idea for Trino Python client
-labels: enhancement
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
Issues must be triaged before being labelled as a bug - which confirms
it's a bug to be fixed instead of just using something wrong or being
labelled as an enhancement - which confirms it's something we think
should be added.