### PR TITLE
Improve release process documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ $ tox
 - Create release package and upload it to PyPI
   ```bash
   . .venv/bin/activate && \
-  pip install twine && \
+  pip install twine wheel setuptools && \
   rm -rf dist/ && \
   ./setup.py sdist bdist_wheel && \
   twine upload dist/* && \


### PR DESCRIPTION
wheel may not be preinstalled within a virtual environment and will cause `./setup.py sdist bdist_wheel` to fail with `error: invalid command 'bdist_wheel'`

# Release notes

(x) This is not user-visible and no release notes are required.