### PR TITLE
Make defensive copy of reference types in `ClientSession`

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -119,12 +119,12 @@ class ClientSession(object):
         self._catalog = catalog
         self._schema = schema
         self._source = source
-        self._properties = properties or {}
-        self._headers = headers or {}
+        self._properties = properties.copy() if properties is not None else {}
+        self._headers = headers.copy() if headers is not None else {}
         self._transaction_id = transaction_id
         self._extra_credential = extra_credential
-        self._client_tags = client_tags
-        self._roles = roles or {}
+        self._client_tags = client_tags.copy() if client_tags is not None else list()
+        self._roles = roles.copy() if roles is not None else {}
         self._prepared_statements: Dict[str, str] = {}
         self._object_lock = threading.Lock()
 


### PR DESCRIPTION
If multiple connections are created from same passed parameters (eg session properties, client tags, roles, ...), changes in one connection's client_session should not affect other connections.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
