### PR TITLE
Ignore already removed deallocated prepared statement headers

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -607,7 +607,7 @@ class TrinoRequest(object):
             for name in get_header_values(
                 http_response.headers, constants.HEADER_DEALLOCATED_PREPARE
             ):
-                self._client_session.prepared_statements.pop(name)
+                self._client_session.prepared_statements.pop(name, None)
 
         self._next_uri = response.get("nextUri")
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Resolves #248 

`X-Trino-Deallocated-Prepare` may appear on multiple responses. Query execution should not fail on prepared statement removal if the prepared statement has already been removed.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix failure on already removed deallocated prepared statement headers
```
