### PR TITLE
Pass additional_headers to cursor.execute

### DIFF
--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -405,7 +405,7 @@ class Cursor(object):
     def _generate_unique_statement_name(self):
         return 'st_' + uuid.uuid4().hex.replace('-', '')
 
-    def execute(self, operation, params=None):
+    def execute(self, operation, params=None, additional_http_headers=None):
         if params:
             assert isinstance(params, (list, tuple)), (
                 'params must be a list or tuple containing the query '
@@ -421,7 +421,7 @@ class Cursor(object):
                 self._query = self._execute_prepared_statement(
                     statement_name, params
                 )
-                result = self._query.execute()
+                result = self._query.execute(additional_http_headers=additional_http_headers)
             finally:
                 # Send deallocate statement
                 # At this point the query can be deallocated since it has already
@@ -432,7 +432,7 @@ class Cursor(object):
         else:
             self._query = trino.client.TrinoQuery(self._request, sql=operation,
                                                   experimental_python_types=self._experimental_pyton_types)
-            result = self._query.execute()
+            result = self._query.execute(additional_http_headers=additional_http_headers)
         self._iterator = iter(result)
         return result
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This adds the ability to specify `additional_http_headers` in `Cursor.execute`. 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Adds the ability to specify additional HTTP headers when calling Cursor.execute. Since this is already available in `trino.client.TrinoQuery.execute` it is just a matter of exposing it as an argument in Cursor.execute.

This also unblocks me for #264 without making a change that it appears was already decided against. In short, this enables me to add tags on a per query basis even though Trino does not technically support it. See https://github.com/trinodb/trino-python-client/pull/154/files/9dc1e697f2141c1fc89083654b599015679bc456#r795281894



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Expose additional_headers in Cursor.execute. #264 
```
