### PR TITLE
[sqlalchemy] Ensure TrinoDialect.get_table_names only returns real tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ tests_require = all_require + [
     "pytest",
     "pytest-runner",
     "click",
+    "sqlalchemy_utils",
 ]
 
 setup(

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -200,6 +200,7 @@ class TrinoDialect(DefaultDialect):
             SELECT "table_name"
             FROM "information_schema"."tables"
             WHERE "table_schema" = :schema
+              AND "table_type" = 'BASE TABLE'
         """
         ).strip()
         res = connection.execute(sql.text(query), schema=schema)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Per the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/14/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_table_names) the `get_table_names` method is intended to return the real table names, i.e., without views. The PR updates the `get_table_names` to only return real table names whereas previously it returned real tables and views.

Note there were no prior integration tests for the `TrinoDialect.get_view_names` method so I added some to cover this logic and threw in a few extra for free which should cover all the various scenarios.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

> The `TrinoDialect.get_table_names` function logic has changed to adhere to the SQLAlchemy specification. Now only real table names are returned as opposed to both real table and view names.

```markdown
* Return only tables in SQLAlchemy  `get_table_names`. Previously, it contained views. ({issue}`266`)
```