### PR TITLE
[sqlalchemy] Improve the performance of TrinoDialect.get_view_names

### DIFF
--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -215,11 +215,14 @@ class TrinoDialect(DefaultDialect):
         schema = schema or self._get_default_schema_name(connection)
         if schema is None:
             raise exc.NoSuchTableError("schema is required")
+
+        # Querying the information_schema.views table is subpar as it compiles the view definitions.
         query = dedent(
             """
             SELECT "table_name"
-            FROM "information_schema"."views"
+            FROM "information_schema"."tables"
             WHERE "table_schema" = :schema
+              AND "table_type" = 'VIEW'
         """
         ).strip()
         res = connection.execute(sql.text(query), schema=schema)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


Querying the `information_schema.views` table seems to be sub-performant for determining which entities are views—I speculate this is because all the view definitions need to be extracted/compiled. A more performant approach is to use `information_schema.tables` with the appropriate type filter. 

For example for a very large schema at Airbnb (comprising of over 100k entities) the following query,

```sql
SELECT
    table_name
FROM 
    information_schema.tables
WHERE 
    table_schema = '<schema>' AND 
    table_type = 'VIEW'
```

took ~ 5 seconds, whereas:

```sql
SELECT
    table_name
FROM
    information_schema.views
WHERE    
    table_schema = '<schema>'
```

was still running after 10 minutes.

Note there were no prior integration tests for the `TrinoDialect.get_view_names` method so I added some to cover this logic and threw in a few extra for free which should cover all the various scenarios.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Improve the performance of get_view_names in SQLAlchemy. ({issue}`267`)
```
