### PR TITLE
[tests] Fix TrinoDialect.has_schema arguments

### DIFF
--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -81,7 +81,7 @@ def test_select_specific_columns(trino_connection):
 @pytest.mark.parametrize('trino_connection', ['memory'], indirect=True)
 def test_define_and_create_table(trino_connection):
     engine, conn = trino_connection
-    if not engine.dialect.has_schema(engine, "test"):
+    if not engine.dialect.has_schema(conn, "test"):
         engine.execute(sqla.schema.CreateSchema("test"))
     metadata = sqla.MetaData()
     try:
@@ -109,7 +109,7 @@ def test_define_and_create_table(trino_connection):
 def test_insert(trino_connection):
     engine, conn = trino_connection
 
-    if not engine.dialect.has_schema(engine, "test"):
+    if not engine.dialect.has_schema(conn, "test"):
         engine.execute(sqla.schema.CreateSchema("test"))
     metadata = sqla.MetaData()
     try:
@@ -138,7 +138,7 @@ def test_insert(trino_connection):
 @pytest.mark.parametrize('trino_connection', ['memory'], indirect=True)
 def test_insert_multiple_statements(trino_connection):
     engine, conn = trino_connection
-    if not engine.dialect.has_schema(engine, "test"):
+    if not engine.dialect.has_schema(conn, "test"):
         engine.execute(sqla.schema.CreateSchema("test"))
     metadata = sqla.MetaData()
     users = sqla.Table('users',
@@ -322,7 +322,7 @@ def test_cte(trino_connection):
 def test_json_column(trino_connection, json_object):
     engine, conn = trino_connection
 
-    if not engine.dialect.has_schema(engine, "test"):
+    if not engine.dialect.has_schema(conn, "test"):
         engine.execute(sqla.schema.CreateSchema("test"))
     metadata = sqla.MetaData()
 
@@ -350,7 +350,7 @@ def test_json_column(trino_connection, json_object):
 def test_get_table_comment(trino_connection):
     engine, conn = trino_connection
 
-    if not engine.dialect.has_schema(engine, "test"):
+    if not engine.dialect.has_schema(conn, "test"):
         engine.execute(sqla.schema.CreateSchema("test"))
     metadata = sqla.MetaData()
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is where type enforcement would be really helpful (see https://github.com/trinodb/trino-python-client/pull/208). For the SQLAlchemy dialect the `has_schema` method was being passed the SQLAlchemy engine as opposed to the corresponding connection per [here](https://github.com/trinodb/trino-python-client/blob/master/trino/sqlalchemy/dialect.py#L304-L313). Both objects have an `execute(...)` method which is why the tests worked, however I thought it was prudent to make make sure the callers used the correct arguments. 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
