### PR TITLE
Fix exceptions.py typo

### DIFF
--- a/trino/exceptions.py
+++ b/trino/exceptions.py
@@ -98,7 +98,7 @@ class TrinoQueryError(Error):
 
     @property
     def message(self):
-        return self._error.get("message", "Trino did no return an error message")
+        return self._error.get("message", "Trino did not return an error message")
 
     @property
     def error_location(self):


### PR DESCRIPTION
Fix typo in TrinoQueryError custom exception class.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix simple typo in `TrinoQueryError`


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
When the error `TrinoQueryError` the user would see a typo in the error text.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text: 

```markdown
* Fix typo in `TrinoQueryError` error message (Fix exceptions.py typo`276`)
```
