### PR TITLE
Support trailing semicolon in sql statements

### DIFF
--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -1105,3 +1105,16 @@ def test_prepared_statements(run_trino):
     cur.execute('DEALLOCATE PREPARE test_prepared_statements')
     cur.fetchall()
     assert cur._request._client_session.prepared_statements == {}
+
+
+def test_optional_semicolon(run_trino):
+    _, host, port = run_trino
+
+    trino_connection = trino.dbapi.Connection(
+        host=host, port=port, user="test", catalog="tpch"
+    )
+
+    query = 'SELECT 1; \n '
+    cur = trino_connection.cursor()
+    cur.execute(query)
+    assert cur._query._sql == query.replace(';', '')

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -302,6 +302,22 @@ class Cursor(object):
     def setoutputsize(self, size, column):
         raise trino.exceptions.NotSupportedError
 
+    def _remove_trailing_semicolon(self, statement: str) -> str:
+        """
+        Remove a trailing semicolon from sql statement if present
+
+        :param statement: sql statement
+        :return: modified sql statement
+        """
+        if ';' not in statement:
+            return statement
+
+        remove_ws = statement.rstrip()
+        remove_semi = remove_ws.rstrip(';')
+
+        # return statement without trailing semicolon (if present), add trailing whitespace back.
+        return remove_semi + statement[len(remove_ws): len(statement)]
+
     def _prepare_statement(self, statement: str, name: str) -> None:
         """
         Registers a prepared statement for the provided `operation` with the
@@ -406,6 +422,7 @@ class Cursor(object):
         return 'st_' + uuid.uuid4().hex.replace('-', '')
 
     def execute(self, operation, params=None):
+        operation = self._remove_trailing_semicolon(operation)
         if params:
             assert isinstance(params, (list, tuple)), (
                 'params must be a list or tuple containing the query '


### PR DESCRIPTION
Naive implementation of removal of optional trailing semicolon. This allows sql statements passed to `cursor.execute()` to contain an optional trailing semicolon.

- This is meant to address machine-generated queries from api's that append trailing semicolons.
- The implementation does not account for trailing comments, so something like `SELECT 1; -- select statement` will be missed.
- Ideally the Trino server itself would accommodate optional semicolons.
- As an implementation example: Starburst Insights UI behaves similarly - deals with trailing semicolons client-side.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Pandas and several other tools that generate SQL statements and use this driver in a generic way will append semicolon's to the end of their statements.
Optional SQL statements are allowed at the end of many DBAPI drivers for other databases.

### Example:
In **Pandas** the following statement will fail with Trino because it adds a trailing semicolon:
```python
df.to_sql('users', con=engine)
```

To work-around this, the following code is required:
```python
import pandas as pd
from sqlalchemy import create_engine, insert
from sqlalchemy.engine import Connection
from typing import Iterator

def fixsql(pd_table, conn: Connection, keys: list, data_iter: Iterator):
    """
    Custom function to hack around issue with Pandas adding trailing semi-colon.
    If the statement that Pandas generates contains a trailing semicolon, remove
    it before actually executing the query.
    """
    data = [dict(zip(keys, row)) for row in data_iter]
    executable = insert(pd_table.table).values(data) # sqlalchemy.sql.dml.Insert
    statement = str(executable.compile(dialect=conn.dialect, compile_kwargs={"literal_binds": True}))
    print(f'SQL STATEMENT IS: {statement}')
    
    # remove the trailing semicolon if required.
    if statement.strip().endswith(';'):
        statement = statement.rstrip(';', 1)

    # conn.execute can take a string or a `sqlalchemy.sql.expression.Executable`
    result = conn.execute(statement)
    return result.rowcount
    

engine = create_engine('trino://user:pwd@example:8080/hive/default', echo=False)
df = pd.DataFrame({'name' : ['User 1', 'User 2', 'User 3']})
# Pass our "method=fixsql" which will fix the sql before it's submitted to (Trino)
df.to_sql('users', con=engine, method=fixsql)
with engine.connect() as conn:
    df2 = pd.read_sql('select * from users', conn)
    print(df2.head())
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Allows sql statements to contain an optional trailing semicolon.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: