### PR TITLE
Fix refresh tokens flow

### DIFF
--- a/trino/auth.py
+++ b/trino/auth.py
@@ -322,15 +322,13 @@ class _OAuth2TokenBearer(AuthBase):
         auth_info_headers = parse_dict_header(_OAuth2TokenBearer._BEARER_PREFIX.sub("", auth_info, count=1))
 
         auth_server = auth_info_headers.get('x_redirect_server')
-        if auth_server is None:
-            raise exceptions.TrinoAuthError("Error: header info didn't have x_redirect_server")
-
         token_server = auth_info_headers.get('x_token_server')
         if token_server is None:
             raise exceptions.TrinoAuthError("Error: header info didn't have x_token_server")
 
-        # tell app that use this url to proceed with the authentication
-        self._redirect_auth_url(auth_server)
+        if auth_server is not None:
+            # tell app that use this url to proceed with the authentication
+            self._redirect_auth_url(auth_server)
 
         # Consume content and release the original connection
         # to allow our new request to reuse the same one.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes refresh token issue caused by `Error: header info didn't have x_redirect_server`. Trino coordinator with enabled refresh token after access token expiration will respond with only `x_token_server` field in authentication header, if refresh token has expired then coordinator restarts the flow. 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix refresh flow in case Trino cluster has refresh tokens enabled. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
