### PR TITLE
Rename test setup method

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -16,7 +16,7 @@ from trino.transaction import IsolationLevel
 
 
 class TestTrinoDialect:
-    def setup(self):
+    def setup_method(self):
         self.dialect = TrinoDialect()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Get rid of test warnings  as in

```
tests/unit/sqlalchemy/test_dialect.py::TestTrinoDialect::test_isolation_level
  /opt/hostedtoolcache/PyPy/3.8.15/x64/lib/pypy3.8/site-packages/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  tests/unit/sqlalchemy/test_dialect.py::TestTrinoDialect::test_isolation_level is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 332 passed, 13 warnings in 139.68s (0:02:19) =================
```


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
