### PR TITLE
Provide query read-only property on dbapi cursor

### DIFF
--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -82,6 +82,7 @@ def test_select_query(trino_connection):
     assert columns["coordinator"] == "boolean"
     assert columns["state"] == "varchar"
     assert cur.query_id is not None
+    assert cur.query == "SELECT * FROM system.runtime.nodes"
     assert cur.stats is not None
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1006,7 +1006,7 @@ def test_trino_query_response_headers(sample_get_response_data):
     with mock.patch.object(req, 'post', return_value=MockResponse()) as mock_post:
         query = TrinoQuery(
             request=req,
-            sql=sql
+            query=sql
         )
         result = query.execute(additional_http_headers=additional_headers)
 

--- a/trino/client.py
+++ b/trino/client.py
@@ -732,7 +732,7 @@ class TrinoQuery(object):
     def __init__(
             self,
             request: TrinoRequest,
-            sql: str,
+            query: str,
             legacy_primitive_types: bool = False,
     ) -> None:
         self._query_id: Optional[str] = None
@@ -746,7 +746,7 @@ class TrinoQuery(object):
         self._update_type = None
         self._update_count = None
         self._next_uri = None
-        self._sql = sql
+        self._query = query
         self._result: Optional[TrinoResult] = None
         self._legacy_primitive_types = legacy_primitive_types
         self._row_mapper: Optional[RowMapper] = None
@@ -754,6 +754,10 @@ class TrinoQuery(object):
     @property
     def query_id(self) -> Optional[str]:
         return self._query_id
+
+    @property
+    def query(self) -> Optional[str]:
+        return self._query
 
     @property
     def columns(self):
@@ -799,7 +803,7 @@ class TrinoQuery(object):
         if self.cancelled:
             raise exceptions.TrinoUserError("Query has been cancelled", self.query_id)
 
-        response = self._request.post(self._sql, additional_http_headers)
+        response = self._request.post(self._query, additional_http_headers)
         status = self._request.process(response)
         self._info_uri = status.info_uri
         self._query_id = status.id

--- a/trino/client.py
+++ b/trino/client.py
@@ -735,8 +735,7 @@ class TrinoQuery(object):
             sql: str,
             legacy_primitive_types: bool = False,
     ) -> None:
-        self.query_id: Optional[str] = None
-
+        self._query_id: Optional[str] = None
         self._stats: Dict[Any, Any] = {}
         self._info_uri: Optional[str] = None
         self._warnings: List[Dict[Any, Any]] = []
@@ -751,6 +750,10 @@ class TrinoQuery(object):
         self._result: Optional[TrinoResult] = None
         self._legacy_primitive_types = legacy_primitive_types
         self._row_mapper: Optional[RowMapper] = None
+
+    @property
+    def query_id(self) -> Optional[str]:
+        return self._query_id
 
     @property
     def columns(self):
@@ -799,7 +802,7 @@ class TrinoQuery(object):
         response = self._request.post(self._sql, additional_http_headers)
         status = self._request.process(response)
         self._info_uri = status.info_uri
-        self.query_id = status.id
+        self._query_id = status.id
         self._stats.update({"queryId": self.query_id})
         self._update_state(status)
         self._warnings = getattr(status, "warnings", [])

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -344,6 +344,12 @@ class Cursor(object):
         return None
 
     @property
+    def query(self) -> Optional[str]:
+        if self._query is not None:
+            return self._query.query
+        return None
+
+    @property
     def warnings(self):
         if self._query is not None:
             return self._query.warnings
@@ -364,7 +370,7 @@ class Cursor(object):
         :param name: name that will be assigned to the prepared statement.
         """
         sql = f"PREPARE {name} FROM {statement}"
-        query = trino.client.TrinoQuery(self.connection._create_request(), sql=sql,
+        query = trino.client.TrinoQuery(self.connection._create_request(), query=sql,
                                         legacy_primitive_types=self._legacy_primitive_types)
         query.execute()
 
@@ -374,7 +380,7 @@ class Cursor(object):
         params
     ):
         sql = 'EXECUTE ' + statement_name + ' USING ' + ','.join(map(self._format_prepared_param, params))
-        return trino.client.TrinoQuery(self._request, sql=sql, legacy_primitive_types=self._legacy_primitive_types)
+        return trino.client.TrinoQuery(self._request, query=sql, legacy_primitive_types=self._legacy_primitive_types)
 
     def _format_prepared_param(self, param):
         """
@@ -454,7 +460,7 @@ class Cursor(object):
 
     def _deallocate_prepared_statement(self, statement_name: str) -> None:
         sql = 'DEALLOCATE PREPARE ' + statement_name
-        query = trino.client.TrinoQuery(self.connection._create_request(), sql=sql,
+        query = trino.client.TrinoQuery(self.connection._create_request(), query=sql,
                                         legacy_primitive_types=self._legacy_primitive_types)
         query.execute()
 
@@ -486,7 +492,7 @@ class Cursor(object):
                 self._deallocate_prepared_statement(statement_name)
 
         else:
-            self._query = trino.client.TrinoQuery(self._request, sql=operation,
+            self._query = trino.client.TrinoQuery(self._request, query=operation,
                                                   legacy_primitive_types=self._legacy_primitive_types)
             self._iterator = iter(self._query.execute())
         return self
@@ -582,7 +588,7 @@ class Cursor(object):
             sql = f"DESCRIBE OUTPUT {statement_name}"
             self._query = trino.client.TrinoQuery(
                 self._request,
-                sql=sql,
+                query=sql,
                 legacy_primitive_types=self._legacy_primitive_types,
             )
             result = self._query.execute()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Provide sql read-only property on dbapi cursor

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Provide executed SQL statement as a read-only property on dbapi's cursor
```
