### PR TITLE
Support setting session properties on a individual statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ conn = trino.dbapi.connect(
 )
 ```
 
+## Session properties
+
+Session properties can be set on the connection
+
+```python
+import trino
+conn = trino.dbapi.connect(
+    ...,
+    session_properties={"query_max_run_time": "1d"}
+)
+```
+
+### Statement properties
+
+It's also possible to set a session property for a specific statement by setting it on the Cursor. This is especially handy in the case of hive partitions.
+
+```python
+import trino
+conn = trino.dbapi.connect()
+cur = conn.cursor(statement_properties={"hive.insert_existing_partitions_behavior": "OVERWRITE"})
+cur.execute("INSERT INTO hive_partitioned_table SELECT * from another_table")
+```
+
 ## Timezone
 
 The time zone for the session can be explicitly set using the IANA time zone

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -1381,6 +1381,22 @@ def test_rowcount_insert(trino_connection):
         assert cur.rowcount == 1
 
 
+def test_statement_properties(trino_connection):
+    exchange_compression_statement = "SHOW SESSION LIKE 'exchange_compression'"
+    cur = trino_connection.cursor()
+    cur.execute(exchange_compression_statement)
+    result = cur.fetchall()
+    assert result[0][1] == "false"
+    cur = trino_connection.cursor(statement_properties={"exchange_compression": True})
+    cur.execute(exchange_compression_statement)
+    result = cur.fetchall()
+    assert result[0][1] == "True"
+    cur = trino_connection.cursor()
+    cur.execute(exchange_compression_statement)
+    result = cur.fetchall()
+    assert result[0][1] == "false"
+
+
 def assert_cursor_description(cur, trino_type, size=None, precision=None, scale=None):
     assert cur.description[0][1] == trino_type
     assert cur.description[0][2] is None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1011,7 +1011,7 @@ def test_trino_query_response_headers(sample_get_response_data):
         result = query.execute(additional_http_headers=additional_headers)
 
         # Validate the the post function was called with the right argguments
-        mock_post.assert_called_once_with(sql, additional_headers)
+        mock_post.assert_called_once_with(sql, additional_headers, None)
 
         # Validate the result is an instance of TrinoResult
         assert isinstance(result, TrinoResult)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Sometimes people want to set certain session properties on a single statement. This feature makes this much easier to manage as it avoids the state management involved with SET to the desired value and resetting back to the original value (which might not be the default value so RESET cannot be used).

Other DBMS have similar feature, eg. statement_params in Snowflake.

Some common use cases are setting different limits on query time or INSERT OVERWRITE in hive.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
* Support setting session properties on individual statements
```
