### PR TITLE
feat(sqlalchemy): Add Support for externalAuthentication

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 from sqlalchemy.engine.url import URL, make_url
 
-from trino.auth import BasicAuthentication
+from trino.auth import BasicAuthentication, OAuth2Authentication
 from trino.dbapi import Connection
 from trino.sqlalchemy import URL as trino_url
 from trino.sqlalchemy.dialect import (
@@ -296,3 +296,12 @@ def test_trino_connection_certificate_auth():
     assert isinstance(cparams['auth'], CertificateAuthentication)
     assert cparams['auth']._cert == cert
     assert cparams['auth']._key == key
+
+
+def test_trino_connection_oauth2_auth():
+    dialect = TrinoDialect()
+    url = make_url('trino://host/?externalAuthentication=true')
+    _, cparams = dialect.create_connect_args(url)
+
+    assert cparams['http_scheme'] == "https"
+    assert isinstance(cparams['auth'], OAuth2Authentication)

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -22,7 +22,12 @@ from sqlalchemy.engine.url import URL
 
 from trino import dbapi as trino_dbapi
 from trino import logging
-from trino.auth import BasicAuthentication, CertificateAuthentication, JWTAuthentication
+from trino.auth import (
+    BasicAuthentication,
+    CertificateAuthentication,
+    JWTAuthentication,
+    OAuth2Authentication,
+)
 from trino.dbapi import Cursor
 from trino.sqlalchemy import compiler, datatype, error
 
@@ -112,6 +117,10 @@ class TrinoDialect(DefaultDialect):
         if "cert" and "key" in url.query:
             kwargs["http_scheme"] = "https"
             kwargs["auth"] = CertificateAuthentication(unquote_plus(url.query['cert']), unquote_plus(url.query['key']))
+
+        if "externalAuthentication" in url.query:
+            kwargs["http_scheme"] = "https"
+            kwargs["auth"] = OAuth2Authentication()
 
         if "source" in url.query:
             kwargs["source"] = unquote_plus(url.query["source"])


### PR DESCRIPTION
## Description
Adds support for the 'externalAuthentication' Trino query URL parameter.

If 'externalAuthentication' is passed on the query arguments:
- Sets 'http_scheme' to 'https' 
- Sets 'auth' to OAuth2Authentication()

## Non-technical explanation
It allows to use SQLAlchemy with OAuth2Authentication.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
* Add support to 'externalAuthentication' SQLAlchemy URL parameter.  ({issue}`#343`)
```

closes #343 
