### PR TITLE
Support SET SESSION AUTHORIZATION on trino-python-client

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -90,6 +90,7 @@ def test_request_headers(mock_get_and_post):
     catalog = "test_catalog"
     schema = "test_schema"
     user = "test_user"
+    authorization_user = "test_authorization_user"
     source = "test_source"
     timezone = "Europe/Brussels"
     accept_encoding_header = "accept-encoding"
@@ -103,6 +104,7 @@ def test_request_headers(mock_get_and_post):
             port=8080,
             client_session=ClientSession(
                 user=user,
+                authorization_user=authorization_user,
                 source=source,
                 catalog=catalog,
                 schema=schema,
@@ -127,6 +129,7 @@ def test_request_headers(mock_get_and_post):
         assert headers[constants.HEADER_SCHEMA] == schema
         assert headers[constants.HEADER_SOURCE] == source
         assert headers[constants.HEADER_USER] == user
+        assert headers[constants.HEADER_AUTHORIZATION_USER] == authorization_user
         assert headers[constants.HEADER_SESSION] == ""
         assert headers[constants.HEADER_TRANSACTION] is None
         assert headers[constants.HEADER_TIMEZONE] == timezone
@@ -140,7 +143,7 @@ def test_request_headers(mock_get_and_post):
             "catalog2=" + urllib.parse.quote("ROLE{catalog2_role}")
         )
         assert headers["User-Agent"] == f"{constants.CLIENT_NAME}/{__version__}"
-        assert len(headers.keys()) == 12
+        assert len(headers.keys()) == 13
 
     req.post("URL")
     _, post_kwargs = post.call_args

--- a/trino/client.py
+++ b/trino/client.py
@@ -82,6 +82,8 @@ class ClientSession(object):
 
     :param user: associated with the query. It is useful for access control
                  and query scheduling.
+    :param authorization_user: associated with the query. It is useful for access control
+                               and query scheduling.
     :param source: associated with the query. It is useful for access
                    control and query scheduling.
     :param catalog: to query. The *catalog* is associated with a Trino
@@ -113,6 +115,7 @@ class ClientSession(object):
     def __init__(
         self,
         user: str,
+        authorization_user: str = None,
         catalog: str = None,
         schema: str = None,
         source: str = None,
@@ -125,6 +128,7 @@ class ClientSession(object):
         timezone: str = None,
     ):
         self._user = user
+        self._authorization_user = authorization_user
         self._catalog = catalog
         self._schema = schema
         self._source = source
@@ -143,6 +147,16 @@ class ClientSession(object):
     @property
     def user(self):
         return self._user
+
+    @property
+    def authorization_user(self):
+        with self._object_lock:
+            return self._authorization_user
+
+    @authorization_user.setter
+    def authorization_user(self, authorization_user):
+        with self._object_lock:
+            self._authorization_user = authorization_user
 
     @property
     def catalog(self):
@@ -441,6 +455,7 @@ class TrinoRequest(object):
         headers[constants.HEADER_SCHEMA] = self._client_session.schema
         headers[constants.HEADER_SOURCE] = self._client_session.source
         headers[constants.HEADER_USER] = self._client_session.user
+        headers[constants.HEADER_AUTHORIZATION_USER] = self._client_session.authorization_user
         headers[constants.HEADER_TIMEZONE] = self._client_session.timezone
         headers[constants.HEADER_CLIENT_CAPABILITIES] = 'PARAMETRIC_DATETIME'
         headers["user-agent"] = f"{constants.CLIENT_NAME}/{__version__}"
@@ -629,6 +644,12 @@ class TrinoRequest(object):
                 http_response.headers, constants.HEADER_DEALLOCATED_PREPARE
             ):
                 self._client_session.prepared_statements.pop(name, None)
+
+        if constants.HEADER_SET_AUTHORIZATION_USER in http_response.headers:
+            self._client_session.authorization_user = http_response.headers[constants.HEADER_SET_AUTHORIZATION_USER]
+
+        if constants.HEADER_RESET_AUTHORIZATION_USER in http_response.headers:
+            self._client_session.authorization_user = None
 
         self._next_uri = response.get("nextUri")
 

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -56,6 +56,10 @@ HEADER_SET_CATALOG = "X-Trino-Set-Catalog"
 
 HEADER_CLIENT_CAPABILITIES = "X-Trino-Client-Capabilities"
 
+HEADER_AUTHORIZATION_USER = "X-Trino-Authorization-User"
+HEADER_SET_AUTHORIZATION_USER = "X-Trino-Set-Authorization-User"
+HEADER_RESET_AUTHORIZATION_USER = "X-Trino-Reset-Authorization-User"
+
 LENGTH_TYPES = ["char", "varchar"]
 PRECISION_TYPES = ["time", "time with time zone", "timestamp", "timestamp with time zone", "decimal"]
 SCALE_TYPES = ["decimal"]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR is to support `SET SESSION AUTHORIZATION user` and `RESET SESSION AUTHORIZATION` sql commands on the python client. Those 2 sql commands are supported on the server side from this PR https://github.com/trinodb/trino/pull/16067

Related to issue https://github.com/trinodb/trino/issues/2512

Tested locally with the script:
```python
from trino.dbapi import connect

conn = connect(
    host="localhost",
    port=8080,
    user="baozhang",
    catalog="tpch"
)
cur = conn.cursor()

cur.execute("SELECT COUNT(*) FROM tpch.sf1.orders")
rows = cur.fetchall()
assert rows[0][0] == 1500000

cur.execute("SELECT CURRENT_USER")
rows = cur.fetchall()
assert rows[0][0] == 'baozhang'

cur.execute("SET SESSION AUTHORIZATION 'prestodv'")
cur.execute("SELECT CURRENT_USER")
rows = cur.fetchall()
assert rows[0][0] == 'prestodv'

cur.execute("RESET SESSION AUTHORIZATION")
cur.execute("SELECT CURRENT_USER")
rows = cur.fetchall()
assert rows[0][0] == 'baozhang'
```


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

