### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("trino/__init__.py", "rb") as f:
     version = str(ast.literal_eval(trino_version.group(1)))
 
 kerberos_require = ["requests_kerberos"]
-sqlalchemy_require = ["sqlalchemy >= 1.3"]
+sqlalchemy_require = ["sqlalchemy >= 1.3, <2.0.0"]
 external_authentication_token_cache_require = ["keyring"]
 
 # We don't add localstorage_require to all_require as users must explicitly opt in to use keyring.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Limit the sqlachemy version requires to sidestep pandas+sqlalchemy>2.0.0 issues with `pd.read_sql()`, `pd.read_sql_table()` and `pd.read_sql_query()`. See #352

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Installing `trino[sqlalchemy]` installs a version that breaks methods such as `pd.read_sql()` and `pd.read_sql_table()`. This will limit the sqlalchemy version to sidestep these bugs.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Limit the sqlachemy version requires to sidestep pandas+sqlalchemy>2.0.0 issues with `pd.read_sql()`, `pd.read_sql_table()` and `pd.read_sql_query()`. ({Installing trino[sqlalchemy] wont allow pandas.read_sql}`#352`)
```
