### PR TITLE
fix(dbapi): Address timestamp with time zone localization issue

### DIFF
--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -283,14 +283,19 @@ def test_time(trino_connection):
     ).execute()
 
 
-@pytest.mark.skipif(trino_version() == '351', reason="time not rounded correctly in older Trino versions")
-def test_time_with_timezone(trino_connection):
-    query_time_with_timezone(trino_connection, '-08:00')
-    query_time_with_timezone(trino_connection, '+08:00')
-    query_time_with_timezone(trino_connection, '+05:30')
-
-
-def query_time_with_timezone(trino_connection, tz_str: str):
+@pytest.mark.skipif(
+    trino_version() == '351',
+    reason="time not rounded correctly in older Trino versions",
+)
+@pytest.mark.parametrize(
+    'tz_str',
+    [
+        '-08:00',
+        '+08:00',
+        '+05:30',
+    ]
+)
+def test_time_with_timezone(trino_connection, tz_str: str):
     tz = create_timezone(tz_str)
     (
         SqlTest(trino_connection)
@@ -550,17 +555,22 @@ def test_timestamp(trino_connection):
     ).execute()
 
 
-def test_timestamp_with_timezone(trino_connection):
-    query_timestamp_with_timezone(trino_connection, '-08:00')
-    query_timestamp_with_timezone(trino_connection, '+08:00')
-    query_timestamp_with_timezone(trino_connection, '+05:30')
-    query_timestamp_with_timezone(trino_connection, 'US/Eastern')
-    query_timestamp_with_timezone(trino_connection, 'Asia/Kolkata')
-    query_timestamp_with_timezone(trino_connection, 'GMT')
+@pytest.mark.parametrize(
+    'tz_str',
+    [
+        '-08:00',
+        '+08:00',
+        '+05:30',
+        'US/Eastern',
+        'Asia/Kolkata',
+        'GMT',
+    ]
+)
+def test_timestamp_with_timezone(trino_connection, tz_str):
+    def _localize(dt: datetime, tz_str: str) -> datetime:
+        tz = create_timezone(tz_str)
+        return dt.replace(tzinfo=tz) if isinstance(tz, timezone) else tz.localize(dt)
 
-
-def query_timestamp_with_timezone(trino_connection, tz_str):
-    tz = create_timezone(tz_str)
     (
         SqlTest(trino_connection)
         .add_field(
@@ -569,133 +579,129 @@ def query_timestamp_with_timezone(trino_connection, tz_str):
         # min supported timestamp(3) with time zone
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.123 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 12, 34, 56, 123000), tz_str))
         # max supported timestamp(3) with time zone
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999000), tz_str))
         # min value for each precision
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.1 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 100000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 100000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.01 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 10000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 10000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 1000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 100).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 100), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 10).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 10), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 1), tz_str))
         # max value for each precision
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 900000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 900000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.99 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 990000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 990000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999000), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999900).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999900), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.99999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999990).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999990), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999999), tz_str))
         # round down
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.1234561 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123456).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 12, 34, 56, 123456), tz_str))
         # round down, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000000000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         # round down, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000004 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000049 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000005 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000050 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999994 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999999), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999994999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 23, 59, 59, 999999), tz_str))
         # round up
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.123456789 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123457).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 12, 34, 56, 123457), tz_str))
         # round up, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000000500001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 1), tz_str))
         # round up, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000009 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 1), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000099999 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 22, 0, 0, 0, 1), tz_str))
         # round up to next day, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999995 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 23, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999500001 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 23, 0, 0, 0, 0), tz_str))
         # round up to next day, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999999 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 23, 0, 0, 0, 0), tz_str))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999999 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
-        # ce
-        .add_field(
-            sql=f"TIMESTAMP '0001-01-01 01:23:45.123 {tz_str}'",
-            python=datetime(1, 1, 1, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=_localize(datetime(2001, 8, 23, 0, 0, 0, 0), tz_str))
         # Julian calendar
         .add_field(
             sql=f"TIMESTAMP '1582-10-04 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 4, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=_localize(datetime(1582, 10, 4, 1, 23, 45, 123000), tz_str))
         # during switch
         .add_field(
             sql=f"TIMESTAMP '1582-10-05 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 5, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=_localize(datetime(1582, 10, 5, 1, 23, 45, 123000), tz_str))
         # Gregorian calendar
         .add_field(
             sql=f"TIMESTAMP '1582-10-14 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 14, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=_localize(datetime(1582, 10, 14, 1, 23, 45, 123000), tz_str))
     ).execute()
 
 
@@ -707,11 +713,11 @@ def test_timestamp_with_timezone_dst(trino_connection):
         .add_field(
             sql=f"TIMESTAMP '2022-03-27 01:59:59.999999999 {tz_str}'",
             # 2:00:00 (STD) becomes 3:00:00 (DST))
-            python=datetime(2022, 3, 27, 2, 0, 0).replace(tzinfo=tz))
+            python=tz.localize(datetime(2022, 3, 27, 2, 0, 0)))
         .add_field(
             sql=f"TIMESTAMP '2022-10-30 02:59:59.999999999 {tz_str}'",
             # 3:00:00 (DST) becomes 2:00:00 (STD))
-            python=datetime(2022, 10, 30, 3, 0, 0).replace(tzinfo=tz))
+            python=tz.localize(datetime(2022, 10, 30, 3, 0, 0)))
     ).execute()
 
 

--- a/trino/client.py
+++ b/trino/client.py
@@ -1108,8 +1108,10 @@ class TimestampWithTimeZoneValueMapper(TimestampValueMapper):
         datetime_with_fraction, timezone_part = value.rsplit(' ', 1)
         whole_python_temporal_value = datetime_with_fraction[:self.datetime_default_size]
         remaining_fractional_seconds = datetime_with_fraction[self.datetime_default_size + 1:]
+        tz = _create_tzinfo(timezone_part)
+        dt = datetime.fromisoformat(whole_python_temporal_value)
         return TimestampWithTimeZone(
-            datetime.fromisoformat(whole_python_temporal_value).replace(tzinfo=_create_tzinfo(timezone_part)),
+            dt.replace(tzinfo=tz) if isinstance(tz, timezone) else tz.localize(dt),
             _fraction_to_decimal(remaining_fractional_seconds),
         ).round_to(self.precision).to_python_type()
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR addresses https://github.com/trinodb/trino-python-client/issues/366.

Note @mdesmet et al. it doesn't address the time zone conundrum with [fractional times](https://github.com/trinodb/trino-python-client/blob/226b216c946025a19560e51f4794daa027963ba0/trino/client.py#L1017) or times (as opposed to timestamps). Additionally I sense there's an issue with how the [`TimeWithTimeZoneValueMapper`](https://github.com/trinodb/trino-python-client/blob/226b216c946025a19560e51f4794daa027963ba0/trino/client.py#L1068-L1078) works (or doesn't work). 

Specifically, the following Trino query, 

```sql
SELECT TIME '01:00' AT TIME ZONE 'America/Los_Angeles'
```

returns `18:00:00-07:00` when run on 2023-04-28 when daylights savings is in effect for said time zone. In order to resolve this query (I presume) the Trino server has had to taken has taken into account the current date on the server to "anchor" the time, i.e., if one were to run the same query on 2023-01-01 when daylights savings in not in effect the result would be `17:00:00-08:00`. 

The issue is the mapping that @mdesmet outlined is running on the Trino client—which is pseudo agnostic* of the server's timezone—and may be in a different timezone (and thus date) than the Trino server. The problem seems ill-defined, i.e., when mapping this to a Python object localized to a timezone without a numerical offset, i.e., America/Los_Angeles, one first needs to know the underlying date. 

\* Granted the client isn't completely agnostic of the current date on the server, i.e., it can be determined via `SELECT current_date`, however this requires an additional query and there's no guarantee this will be executed on the same date as the primary query.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix localization of timestamp with time zone. ({[366](https://github.com/trinodb/trino-python-client/issues/366)})
```
