### PR TITLE
Address time zone localization issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,12 @@ setup(
         "Topic :: Database :: Front-Ends",
     ],
     python_requires='>=3.7',
-    install_requires=["pytz", "requests", "tzlocal"],
+    install_requires=[
+        "backports.zoneinfo;python_version<'3.9'",
+        "pytz",
+        "requests",
+        "tzlocal",
+    ],
     extras_require={
         "all": all_require,
         "kerberos": kerberos_require,

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         "backports.zoneinfo;python_version<'3.9'",
+        "python-dateutil",
         "pytz",
         "requests",
         "tzlocal",

--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -4,8 +4,12 @@ import uuid
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from decimal import Decimal
 
+try:
+    from zoneinfo import ZoneInfo
+except ModuleNotFoundError:
+    from backports.zoneinfo import ZoneInfo
+
 import pytest
-import pytz
 
 import trino
 from tests.integration.conftest import trino_version
@@ -729,7 +733,7 @@ def create_timezone(timezone_str: str) -> tzinfo:
         else:
             return timezone(-timedelta(hours=hours, minutes=minutes))
     else:
-        return pytz.timezone(timezone_str)
+        return ZoneInfo(timezone_str)
 
 
 def test_interval(trino_connection):

--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -302,114 +302,114 @@ def test_time_with_timezone(trino_connection, tz_str: str):
         # min supported time(3)
         .add_field(
             sql=f"TIME '00:00:00 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '12:34:56.123 {tz_str}'",
-            python=time(12, 34, 56, 123000).replace(tzinfo=tz))
+            python=time(12, 34, 56, 123000, tzinfo=tz))
         # max supported time(3)
         .add_field(
             sql=f"TIME '23:59:59.999 {tz_str}'",
-            python=time(23, 59, 59, 999000).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999000, tzinfo=tz))
         # min value for each precision
         .add_field(
             sql=f"TIME '00:00:00 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.1 {tz_str}'",
-            python=time(0, 0, 0, 100000).replace(tzinfo=tz))
+            python=time(0, 0, 0, 100000, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.01 {tz_str}'",
-            python=time(0, 0, 0, 10000).replace(tzinfo=tz))
+            python=time(0, 0, 0, 10000, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.001 {tz_str}'",
-            python=time(0, 0, 0, 1000).replace(tzinfo=tz))
+            python=time(0, 0, 0, 1000, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.0001 {tz_str}'",
-            python=time(0, 0, 0, 100).replace(tzinfo=tz))
+            python=time(0, 0, 0, 100, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.00001 {tz_str}'",
-            python=time(0, 0, 0, 10).replace(tzinfo=tz))
+            python=time(0, 0, 0, 10, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.000001 {tz_str}'",
-            python=time(0, 0, 0, 1).replace(tzinfo=tz))
+            python=time(0, 0, 0, 1, tzinfo=tz))
         # max value for each precision
         .add_field(
             sql=f"TIME '23:59:59 {tz_str}'",
-            python=time(23, 59, 59).replace(tzinfo=tz))
+            python=time(23, 59, 59, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.9 {tz_str}'",
-            python=time(23, 59, 59, 900000).replace(tzinfo=tz))
+            python=time(23, 59, 59, 900000, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.99 {tz_str}'",
-            python=time(23, 59, 59, 990000).replace(tzinfo=tz))
+            python=time(23, 59, 59, 990000, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.999 {tz_str}'",
-            python=time(23, 59, 59, 999000).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999000, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.9999 {tz_str}'",
-            python=time(23, 59, 59, 999900).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999900, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.99999 {tz_str}'",
-            python=time(23, 59, 59, 999990).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999990, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.999999 {tz_str}'",
-            python=time(23, 59, 59, 999999).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999999, tzinfo=tz))
         # round down
         .add_field(
             sql=f"TIME '12:34:56.1234561 {tz_str}'",
-            python=time(12, 34, 56, 123456).replace(tzinfo=tz))
+            python=time(12, 34, 56, 123456, tzinfo=tz))
         # round down, min value
         .add_field(
             sql=f"TIME '00:00:00.000000000001 {tz_str}'",
-            python=time(0, 0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.0000001 {tz_str}'",
-            python=time(0, 0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, 0, tzinfo=tz))
         # round down, max value
         .add_field(
             sql=f"TIME '00:00:00.0000004 {tz_str}'",
-            python=time(0, 0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.00000049 {tz_str}'",
-            python=time(0, 0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.0000005 {tz_str}'",
-            python=time(0, 0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.9999994 {tz_str}'",
-            python=time(23, 59, 59, 999999).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999999, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.9999994999 {tz_str}'",
-            python=time(23, 59, 59, 999999).replace(tzinfo=tz))
+            python=time(23, 59, 59, 999999, tzinfo=tz))
         # round up
         .add_field(
             sql=f"TIME '12:34:56.123456789 {tz_str}'",
-            python=time(12, 34, 56, 123457).replace(tzinfo=tz))
+            python=time(12, 34, 56, 123457, tzinfo=tz))
         # round up, min value
         .add_field(
             sql=f"TIME '00:00:00.000000500001 {tz_str}'",
-            python=time(0, 0, 0, 1).replace(tzinfo=tz))
+            python=time(0, 0, 0, 1, tzinfo=tz))
         # round up, max value
         .add_field(
             sql=f"TIME '00:00:00.0000009 {tz_str}'",
-            python=time(0, 0, 0, 1).replace(tzinfo=tz))
+            python=time(0, 0, 0, 1, tzinfo=tz))
         .add_field(
             sql=f"TIME '00:00:00.00000099999 {tz_str}'",
-            python=time(0, 0, 0, 1).replace(tzinfo=tz))
+            python=time(0, 0, 0, 1, tzinfo=tz))
         # round up to next day, min value
         .add_field(
             sql=f"TIME '23:59:59.9999995 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.999999500001 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
         # round up to next day, max value
         .add_field(
             sql=f"TIME '23:59:59.9999999 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIME '23:59:59.999999999 {tz_str}'",
-            python=time(0, 0, 0).replace(tzinfo=tz))
+            python=time(0, 0, 0, tzinfo=tz))
     ).execute()
 
 
@@ -572,133 +572,133 @@ def test_timestamp_with_timezone(trino_connection, tz_str):
         # min supported timestamp(3) with time zone
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.123 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 12, 34, 56, 123000, tzinfo=tz))
         # max supported timestamp(3) with time zone
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999000, tzinfo=tz))
         # min value for each precision
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.1 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 100000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 100000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.01 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 10000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 10000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 1000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 100).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 100, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 10).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 10, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 1, tzinfo=tz))
         # max value for each precision
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 900000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 900000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.99 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 990000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 990000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999000).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999000, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999900).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999900, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.99999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999990).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999990, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999999, tzinfo=tz))
         # round down
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.1234561 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123456).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 12, 34, 56, 123456, tzinfo=tz))
         # round down, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000000000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         # round down, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000004 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000049 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000005 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000050 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999994 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999999, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999994999 {tz_str}'",
-            python=datetime(2001, 8, 22, 23, 59, 59, 999999).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 23, 59, 59, 999999, tzinfo=tz))
         # round up
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 12:34:56.123456789 {tz_str}'",
-            python=datetime(2001, 8, 22, 12, 34, 56, 123457).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 12, 34, 56, 123457, tzinfo=tz))
         # round up, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.000000500001 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 1, tzinfo=tz))
         # round up, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.0000009 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 1, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 00:00:00.00000099999 {tz_str}'",
-            python=datetime(2001, 8, 22, 0, 0, 0, 1).replace(tzinfo=tz))
+            python=datetime(2001, 8, 22, 0, 0, 0, 1, tzinfo=tz))
         # round up to next day, min value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999995 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 23, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999500001 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 23, 0, 0, 0, 0, tzinfo=tz))
         # round up to next day, max value
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.9999999 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 23, 0, 0, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2001-08-22 23:59:59.999999999 {tz_str}'",
-            python=datetime(2001, 8, 23, 0, 0, 0, 0).replace(tzinfo=tz))
+            python=datetime(2001, 8, 23, 0, 0, 0, 0, tzinfo=tz))
         # ce
         .add_field(
             sql=f"TIMESTAMP '0001-01-01 01:23:45.123 {tz_str}'",
-            python=datetime(1, 1, 1, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=datetime(1, 1, 1, 1, 23, 45, 123000, tzinfo=tz))
         # Julian calendar
         .add_field(
             sql=f"TIMESTAMP '1582-10-04 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 4, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=datetime(1582, 10, 4, 1, 23, 45, 123000, tzinfo=tz))
         # during switch
         .add_field(
             sql=f"TIMESTAMP '1582-10-05 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 5, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=datetime(1582, 10, 5, 1, 23, 45, 123000, tzinfo=tz))
         # Gregorian calendar
         .add_field(
             sql=f"TIMESTAMP '1582-10-14 01:23:45.123 {tz_str}'",
-            python=datetime(1582, 10, 14, 1, 23, 45, 123000).replace(tzinfo=tz))
+            python=datetime(1582, 10, 14, 1, 23, 45, 123000, tzinfo=tz))
     ).execute()
 
 
@@ -710,11 +710,11 @@ def test_timestamp_with_timezone_dst(trino_connection):
         .add_field(
             sql=f"TIMESTAMP '2022-03-27 01:59:59.999999999 {tz_str}'",
             # 2:00:00 (STD) becomes 3:00:00 (DST))
-            python=datetime(2022, 3, 27, 2, 0, 0).replace(tzinfo=tz))
+            python=datetime(2022, 3, 27, 2, 0, 0, tzinfo=tz))
         .add_field(
             sql=f"TIMESTAMP '2022-10-30 02:59:59.999999999 {tz_str}'",
             # 3:00:00 (DST) becomes 2:00:00 (STD))
-            python=datetime(2022, 10, 30, 3, 0, 0).replace(tzinfo=tz))
+            python=datetime(2022, 10, 30, 3, 0, 0, tzinfo=tz))
     ).execute()
 
 

--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -284,13 +284,15 @@ def test_time(trino_connection):
 
 
 @pytest.mark.skipif(trino_version() == '351', reason="time not rounded correctly in older Trino versions")
-def test_time_with_timezone(trino_connection):
-    query_time_with_timezone(trino_connection, '-08:00')
-    query_time_with_timezone(trino_connection, '+08:00')
-    query_time_with_timezone(trino_connection, '+05:30')
-
-
-def query_time_with_timezone(trino_connection, tz_str: str):
+@pytest.mark.parametrize(
+    'tz_str',
+    [
+        '-08:00',
+        '+08:00',
+        '+05:30',
+    ]
+)
+def test_time_with_timezone(trino_connection, tz_str: str):
     tz = create_timezone(tz_str)
     (
         SqlTest(trino_connection)
@@ -550,16 +552,17 @@ def test_timestamp(trino_connection):
     ).execute()
 
 
-def test_timestamp_with_timezone(trino_connection):
-    query_timestamp_with_timezone(trino_connection, '-08:00')
-    query_timestamp_with_timezone(trino_connection, '+08:00')
-    query_timestamp_with_timezone(trino_connection, '+05:30')
-    query_timestamp_with_timezone(trino_connection, 'US/Eastern')
-    query_timestamp_with_timezone(trino_connection, 'Asia/Kolkata')
-    query_timestamp_with_timezone(trino_connection, 'GMT')
-
-
-def query_timestamp_with_timezone(trino_connection, tz_str):
+@pytest.mark.parametrize(
+    'tz_str',
+    [
+        '-08:00',
+        '+08:00',
+        'US/Eastern',
+        'Asia/Kolkata',
+        'GMT',
+    ]
+)
+def test_timestamp_with_timezone(trino_connection, tz_str):
     tz = create_timezone(tz_str)
     (
         SqlTest(trino_connection)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR addresses https://github.com/trinodb/trino-python-client/issues/366. 

Per [this](https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html) article, there seemed to be merit in removing `pytz` in favor of `dateutil.tz` given that in Python 3.6 the `datetime` module remedied the ambiguous datetimes due to daylight saving time transition. 

Regrettably though one cannot obtain the IANA name from a `dateutil.tz` time zone—which is required when transpiling `datetime.time`/`datetime.datetime` objects to Trino SQL when provided as operation parameters. Instead we use the `zoneinfo` package (added to Python’s standard library in Python 3.9 and back ported) which does provide a mechanism of obtaining the specified IANA name from a `datetime.datetime`/`datetime.time` object, i.e., 

```python
>>> from datetime import time
>>> from zoneinfo import ZoneInfo
>>>
>>> midnight = time(0, tzinfo=ZoneInfo("America/Los_Angeles"))
>>> midnight.tzinfo.key 
'America/Los_Angeles'
```


The fix is rather simple as simply switching out the `pytz` package for the `zoneinfo` package remedies the issue:

```
>>> from datetime import datetime
>>> import pytz
>>>
>>> datetime(2023, 1, 1, tzinfo=pytz.timezone("America/Los_Angeles")).isoformat()
'2023-01-01T00:00:00-07:53' 
```

```
>>> from datetime import datetime
>>> import zoneinfo
>>>
>>> datetime(2023, 1, 1, tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles")).isoformat()
'2023-01-01T00:00:00-08:00'
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fixes time zone localization. The `pytz` package for encoding/decoding time zones has been deprecated in favor of `zoneinfo`. Time zones should now be encoded (when specifying execution parameters) using the `zoneinfo.ZoneInfo` method as opposed to `pytz.timezone` method. ({[issue](https://github.com/trinodb/trino-python-client/issues/366.)}`366`)
```
