### PR TITLE
Use `EXECUTE IMMEDIATE` for parameterized statement executions

### DIFF
--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -23,8 +23,11 @@ from trino.sqlalchemy.datatype import JSON
 @pytest.fixture
 def trino_connection(run_trino, request):
     _, host, port = run_trino
+    connect_args = {"source": "test", "max_attempts": 1}
+    if trino_version() <= '417':
+        connect_args["legacy_prepared_statements"] = True
     engine = sqla.create_engine(f"trino://test@{host}:{port}/{request.param}",
-                                connect_args={"source": "test", "max_attempts": 1})
+                                connect_args=connect_args)
     yield engine, engine.connect()
 
 

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -128,6 +128,9 @@ class TrinoDialect(DefaultDialect):
         if "legacy_primitive_types" in url.query:
             kwargs["legacy_primitive_types"] = json.loads(unquote_plus(url.query["legacy_primitive_types"]))
 
+        if "legacy_prepared_statements" in url.query:
+            kwargs["legacy_prepared_statements"] = unquote_plus(url.query["legacy_prepared_statements"])
+
         if "verify" in url.query:
             kwargs["verify"] = json.loads(unquote_plus(url.query["verify"]))
 

--- a/trino/sqlalchemy/util.py
+++ b/trino/sqlalchemy/util.py
@@ -23,6 +23,7 @@ def _url(
     extra_credential: Optional[List[Tuple[str, str]]] = None,
     client_tags: Optional[List[str]] = None,
     legacy_primitive_types: Optional[bool] = None,
+    legacy_prepared_statements: Optional[bool] = None,
     access_token: Optional[str] = None,
     cert: Optional[str] = None,
     key: Optional[str] = None,
@@ -84,6 +85,9 @@ def _url(
 
     if legacy_primitive_types is not None:
         trino_url += f"&legacy_primitive_types={json.dumps(legacy_primitive_types)}"
+
+    if legacy_prepared_statements is not None:
+        trino_url += f"&legacy_prepared_statements={json.dumps(legacy_prepared_statements)}"
 
     if access_token is not None:
         trino_url += f"&access_token={quote_plus(access_token)}"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make parametrized statement executions more efficient by taking advantage of https://github.com/trinodb/trino/pull/17341.

When running against older versions of Trino that don't support the `EXECUTE IMMEDIATE` statement, the old behavior can be restored by passing `legacy_prepared_statements=True` when creating a connection.

Draft PR until the back-end change is released.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
