### PR TITLE
Add support for trino catalog when autoloading table metadata

### DIFF
--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -524,6 +524,7 @@ def _num_queries_containing_string(connection, query_string):
     return len(list(filter(lambda rec: query_string in rec[0], rows)))
 
 
+@pytest.mark.parametrize('trino_connection', ['memory'], indirect=True)
 def test_table_from_other_catalog(trino_connection):
     engine, _ = trino_connection
     t = sqla.Table(

--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -522,3 +522,15 @@ def _num_queries_containing_string(connection, query_string):
     result = connection.execute(statement)
     rows = result.fetchall()
     return len(list(filter(lambda rec: query_string in rec[0], rows)))
+
+
+def test_table_from_other_catalog(trino_connection):
+    engine, _ = trino_connection
+    t = sqla.Table(
+        "catalogs",
+        sqla.MetaData(),
+        schema="metadata",
+        trino_catalog="system",
+        autoload_with=engine,
+    )
+    assert "system" in set(sqla.select(t.c.catalog_name).scalars())

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -327,7 +327,9 @@ class TrinoDialect(DefaultDialect):
         res = connection.execute(sql.text(query), {"schema": schema})
         return res.first() is not None
 
-    def has_table(self, connection: Connection, table_name: str, schema: str = None, **kw) -> bool:
+    def has_table(
+        self, connection: Connection, table_name: str, schema: str = None, trino_catalog: str = None, **kw
+    ) -> bool:
         schema = schema or self._get_default_schema_name(connection)
         if schema is None:
             return False
@@ -338,8 +340,12 @@ class TrinoDialect(DefaultDialect):
             WHERE "table_schema" = :schema
               AND "table_name" = :table
         """
+            + ('AND "trino_catalog" = :catalog' if trino_catalog is not None else "")
         ).strip()
-        res = connection.execute(sql.text(query), {"schema": schema, "table": table_name})
+        res = connection.execute(
+            sql.text(query),
+            {"schema": schema, "table": table_name, "catalog": trino_catalog},
+        )
         return res.first() is not None
 
     def has_sequence(self, connection: Connection, sequence_name: str, schema: str = None, **kw) -> bool:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Support autoloading metadata from different catalogs.

Fixes #389.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Users can now load metadata from a catalog that is different from the one they initially connected to.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text: 

```markdown
* Support autoloading metadata from different catalogs using sqlalchemy Table autoloading.
```
