### PR TITLE
Add import_dbapi to get rid of the warning

### DIFF
--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -73,6 +73,13 @@ class TrinoDialect(DefaultDialect):
         """
         return trino_dbapi
 
+    @classmethod
+    def import_dbapi(cls):
+        """
+        ref: https://www.python.org/dev/peps/pep-0249/#module-interface
+        """
+        return trino_dbapi
+
     def create_connect_args(self, url: URL) -> Tuple[Sequence[Any], Mapping[str, Any]]:
         args: Sequence[Any] = list()
         kwargs: Dict[str, Any] = dict(host=url.host)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Get rid of the warning:
```
<ipython-input-2-dbb9b13e8995>:4: SADeprecationWarning: The dbapi() classmethod on dialect classes has been renamed to import_dbapi().  Implement an import_dbapi() classmethod directly on class <class 'trino.sqlalchemy.dialect.TrinoDialect'> to remove this warning; the old .dbapi() classmethod may be maintained for backwards compatibility.
```


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
