### PR TITLE
Wrap all requests.exceptions.RequestException as TrinoConnectionError

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -803,7 +803,10 @@ class TrinoQuery(object):
         if self.cancelled:
             raise exceptions.TrinoUserError("Query has been cancelled", self.query_id)
 
-        response = self._request.post(self._query, additional_http_headers)
+        try:
+            response = self._request.post(self._query, additional_http_headers)
+        except requests.exceptions.RequestException as e:
+            raise trino.exceptions.TrinoConnectionError("failed to execute: {}".format(e))
         status = self._request.process(response)
         self._info_uri = status.info_uri
         self._query_id = status.id
@@ -834,7 +837,10 @@ class TrinoQuery(object):
 
     def fetch(self) -> List[List[Any]]:
         """Continue fetching data for the current query_id"""
-        response = self._request.get(self._request.next_uri)
+        try:
+            response = self._request.get(self._request.next_uri)
+        except requests.exceptions.RequestException as e:
+            raise trino.exceptions.TrinoConnectionError("failed to fetch: {}".format(e))
         status = self._request.process(response)
         self._update_state(status)
         logger.debug(status)
@@ -852,7 +858,10 @@ class TrinoQuery(object):
             return
 
         logger.debug("cancelling query: %s", self.query_id)
-        response = self._request.delete(self._next_uri)
+        try:
+            response = self._request.delete(self._next_uri)
+        except requests.exceptions.RequestException as e:
+            raise trino.exceptions.TrinoConnectionError("failed to cancel query: {}".format(e))
         logger.debug(response)
         if response.status_code == requests.codes.no_content:
             self._cancelled = True

--- a/trino/exceptions.py
+++ b/trino/exceptions.py
@@ -67,6 +67,10 @@ class TrinoAuthError(OperationalError):
     pass
 
 
+class TrinoConnectionError(OperationalError):
+    pass
+
+
 class TrinoDataError(NotSupportedError):
     pass
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Wrap all requests.exceptions.RequestException as TrinoConnectionError.
Fixes #364.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Before this change if a user needed to catch connection errors (e.g. connection refused) they needed to add a dependency on requests and import the relevant exception from requests.exceptions module.

After this change all requests exception get rethrown as a TrinoConnectionError instead.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
