### PR TITLE
Remove unused 'redirect_handler' code

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -117,7 +117,6 @@ def test_request_headers(mock_get_and_post):
                 }
             ),
             http_scheme="http",
-            redirect_handler=None,
         )
 
     def assert_headers(headers):

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -147,7 +147,6 @@ class Connection(object):
         http_scheme=constants.HTTP,
         auth=constants.DEFAULT_AUTH,
         extra_credential=None,
-        redirect_handler=None,
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
         isolation_level=IsolationLevel.AUTOCOMMIT,
@@ -192,7 +191,6 @@ class Connection(object):
         self.http_scheme = http_scheme if not parsed_host.scheme else parsed_host.scheme
         self.auth = auth
         self.extra_credential = extra_credential
-        self.redirect_handler = redirect_handler
         self.max_attempts = max_attempts
         self.request_timeout = request_timeout
         self.client_tags = client_tags
@@ -251,7 +249,6 @@ class Connection(object):
             self._http_session,
             self.http_scheme,
             self.auth,
-            self.redirect_handler,
             self.max_attempts,
             self.request_timeout,
         )


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In be74586c29f2583c3e62de2a07183ad67857511c the redirect_handler code was removed but only partially.

This change removes the rest of the dead code related to redirect_handler.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```