### PR TITLE
Add support to data type MAP in TrinoTypeCompiler

### DIFF
--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -196,6 +196,9 @@ class TrinoTypeCompiler(compiler.GenericTypeCompiler):
     def visit_JSON(self, type_, **kw):
         return 'JSON'
 
+    def visit_MAP(self, type_, **kw):
+        return 'MAP'
+
 
 class TrinoIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = RESERVED_WORDS


### PR DESCRIPTION
Will my attempt to integrate with LangChain and Trino using this library, I countered the following exception:

```
sqlalchemy.exc.CompileError: (in table 'MY_TABLE', column 'SOME_COLUMN'): Compiler <trino.sqlalchemy.compiler.TrinoTypeCompiler object at 0x110fb7d30> can't render element of type MAP

AttributeError: 'TrinoTypeCompiler' object has no attribute 'visit_MAP'
```

After some research, I found out that TrinoTypeCompiler doesn't support MAP data type.
I have edited the compiler so it will support `visit_MAP` function and it worked on my local machine.

Fixes https://github.com/trinodb/trino-python-client/issues/397
