### PR TITLE
implement `get_catalog_names`

### DIFF
--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -410,6 +410,15 @@ def test_json_column(trino_connection, json_object):
         metadata.drop_all(engine)
 
 
+@pytest.mark.parametrize('trino_connection', ['system'], indirect=True)
+def test_get_catalog_names(trino_connection):
+    engine, conn = trino_connection
+
+    schemas = engine.dialect.get_catalog_names(conn)
+    assert len(schemas) == 5
+    assert set(schemas) == {"jmx", "memory", "system", "tpcds", "tpch"}
+
+
 @pytest.mark.parametrize('trino_connection', ['memory'], indirect=True)
 def test_get_table_comment(trino_connection):
     engine, conn = trino_connection

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -192,6 +192,16 @@ class TrinoDialect(DefaultDialect):
         """Trino has no support for foreign keys. Returns an empty list."""
         return []
 
+    def get_catalog_names(self, connection: Connection, **kw) -> List[str]:
+        query = dedent(
+            """
+            SELECT "table_cat"
+            FROM "system"."jdbc"."catalogs"
+        """
+        ).strip()
+        res = connection.execute(sql.text(query))
+        return [row.table_cat for row in res]
+
     def get_schema_names(self, connection: Connection, **kw) -> List[str]:
         query = dedent(
             """


### PR DESCRIPTION
## Description
I'd like to provide standard function `get_catalog_names` in SQLAlchemy's `TrinoDialect`.  
This function could be used to list and switch between catalogs by client like proposed in Superset [SIP-95](https://github.com/apache/superset/issues/22862)

## Non-technical explanation



## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
