### PR TITLE
Prevent error when closing an unused cursor

### DIFF
--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -706,7 +706,8 @@ class Cursor(object):
         self._query.cancel()
 
     def close(self):
-        self.cancel()
+        if self._query is not None:
+            self.cancel()
         # TODO: Cancel not only the last query executed on this cursor
         #  but also any other outstanding queries executed through this cursor.
 


### PR DESCRIPTION
SQLAlchemy will attempt to close cursor objects even if, for whatever reason, they haven't actually been used and therefore have no associated query to cancel.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
* Support cleanly closing unused cursor
```
