### PR TITLE
add Trino Python Client version to user agent

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -118,7 +118,7 @@ the code base like `ttl` are allowed and encouraged.
   ```bash
   git fetch -a && git status
   ```
-- Change version in `trino/__init__.py` to a new version, e.g. `0.123.0`.
+- Change version in `trino/_version.py` to a new version, e.g. `0.123.0`.
 - Commit
   ```bash
   git commit -a -m "Bump version to 0.123.0"

--- a/setup.py
+++ b/setup.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
-import re
+import os
 import textwrap
+from codecs import open
+from typing import Any
 
 from setuptools import find_packages, setup
 
-_version_re = re.compile(r"__version__\s+=\s+(.*)")
-
-with open("trino/__init__.py", "rb") as f:
-    trino_version = _version_re.search(f.read().decode("utf-8"))
-    assert trino_version is not None
-    version = str(ast.literal_eval(trino_version.group(1)))
+about = {}  # type: dict[str, Any]
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, "trino", "_version.py"), "r", "utf-8") as f:
+    exec(f.read(), about)
 
 kerberos_require = ["requests_kerberos"]
 sqlalchemy_require = ["sqlalchemy >= 1.3"]
@@ -44,14 +43,14 @@ tests_require = all_require + [
 ]
 
 setup(
-    name="trino",
-    author="Trino Team",
-    author_email="python-client@trino.io",
-    version=version,
-    url="https://github.com/trinodb/trino-python-client",
+    name=about["__title__"],
+    author=about["__author__"],
+    author_email=about["__author_email__"],
+    version=about["__version__"],
+    url=about["__url__"],
     packages=find_packages(include=["trino", "trino.*"]),
     package_data={"": ["LICENSE", "README.md"]},
-    description="Client for the Trino distributed SQL Engine",
+    description=about["__description__"],
     long_description=textwrap.dedent(
         """
     Client for Trino (https://trino.io), a distributed SQL engine for
@@ -59,7 +58,7 @@ setup(
     a DBAPI 2.0 implementation.
     """
     ),
-    license="Apache 2.0",
+    license=about["__license__"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -38,7 +38,7 @@ from tests.unit.oauth_test_utils import (
     _get_token_requests,
     _post_statement_requests,
 )
-from trino import constants
+from trino import __version__, constants
 from trino.auth import KerberosAuthentication, _OAuth2TokenBearer
 from trino.client import (
     ClientSession,
@@ -125,6 +125,7 @@ def test_request_headers(mock_get_and_post):
         assert headers[constants.HEADER_SOURCE] == source
         assert headers[constants.HEADER_USER] == user
         assert headers[constants.HEADER_SESSION] == ""
+        assert headers[constants.HEADER_TRANSACTION] is None
         assert headers[constants.HEADER_TIMEZONE] == timezone
         assert headers[constants.HEADER_CLIENT_CAPABILITIES] == "PARAMETRIC_DATETIME"
         assert headers[accept_encoding_header] == accept_encoding_value
@@ -135,7 +136,8 @@ def test_request_headers(mock_get_and_post):
             "catalog1=NONE,"
             "catalog2=" + urllib.parse.quote("ROLE{catalog2_role}")
         )
-        assert len(headers.keys()) == 11
+        assert headers["User-Agent"] == f"{constants.CLIENT_NAME}/{__version__}"
+        assert len(headers.keys()) == 12
 
     req.post("URL")
     _, post_kwargs = post.call_args

--- a/trino/__init__.py
+++ b/trino/__init__.py
@@ -11,7 +11,28 @@
 # limitations under the License.
 
 from . import auth, client, constants, dbapi, exceptions, logging
+from ._version import (
+    __author__,
+    __author_email__,
+    __description__,
+    __license__,
+    __title__,
+    __url__,
+    __version__,
+)
 
-__all__ = ['auth', 'dbapi', 'client', 'constants', 'exceptions', 'logging']
-
-__version__ = "0.326.0"
+__all__ = [
+    "auth",
+    "client",
+    "constants",
+    "dbapi",
+    "exceptions",
+    "logging",
+    "__author__",
+    "__author_email__",
+    "__description__",
+    "__license__",
+    "__title__",
+    "__url__",
+    "__version__",
+]

--- a/trino/_version.py
+++ b/trino/_version.py
@@ -1,0 +1,7 @@
+__title__ = "trino"
+__description__ = "Client for the Trino distributed SQL Engine"
+__url__ = "https://github.com/trinodb/trino-python-client"
+__version__ = "0.326.0"
+__author__ = "Trino Team"
+__author_email__ = "python-client@trino.io"
+__license__ = "Apache 2.0"

--- a/trino/client.py
+++ b/trino/client.py
@@ -62,6 +62,7 @@ from tzlocal import get_localzone_name  # type: ignore
 
 import trino.logging
 from trino import constants, exceptions
+from trino._version import __version__
 
 __all__ = ["ClientSession", "TrinoQuery", "TrinoRequest", "PROXIES"]
 
@@ -447,7 +448,7 @@ class TrinoRequest(object):
 
     @property
     def http_headers(self) -> Dict[str, str]:
-        headers = {}
+        headers = requests.structures.CaseInsensitiveDict()
 
         headers[constants.HEADER_CATALOG] = self._client_session.catalog
         headers[constants.HEADER_SCHEMA] = self._client_session.schema
@@ -455,6 +456,7 @@ class TrinoRequest(object):
         headers[constants.HEADER_USER] = self._client_session.user
         headers[constants.HEADER_TIMEZONE] = self._client_session.timezone
         headers[constants.HEADER_CLIENT_CAPABILITIES] = 'PARAMETRIC_DATETIME'
+        headers["user-agent"] = f"{constants.CLIENT_NAME}/{__version__}"
         if len(self._client_session.roles.values()):
             headers[constants.HEADER_ROLE] = ",".join(
                 # ``name`` must not contain ``=``

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -26,6 +26,8 @@ HTTPS = "https"
 
 URL_STATEMENT_PATH = "/v1/statement"
 
+CLIENT_NAME = "Trino Python Client"
+
 HEADER_CATALOG = "X-Trino-Catalog"
 HEADER_SCHEMA = "X-Trino-Schema"
 HEADER_SOURCE = "X-Trino-Source"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino introduces some breaking changes for old client versions but there is no way to find out the client version of our users to warn them before upgrading to a newer version since the python client is using the default user agent from `requests` that results `python-requests/2.31.0`. However, the JDBC driver [sets](https://github.com/trinodb/trino/blob/423/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java#L123) a more descriptive user agent header value such as `Trino JDBC Driver/371` that helps us to identify users with outdated client versions.

This PR aims to specify the user agent to pass the current driver version to the coordinator to be logged later in query created and completed events as [`io.trino.spi.eventlistener.QueryContext.userAgent`](https://github.com/trinodb/trino/blob/423/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java#L39C1-L39C1).

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This change will allow us to spot outdated clients accessing our Trino cluster.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Add Trino Python Client version to User-Agent header. ({issue}`406`)
```
