### PR TITLE
add Trino Python Client version to user agent

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -38,7 +38,7 @@ from tests.unit.oauth_test_utils import (
     _get_token_requests,
     _post_statement_requests,
 )
-from trino import constants
+from trino import __version__, constants
 from trino.auth import KerberosAuthentication, _OAuth2TokenBearer
 from trino.client import (
     ClientSession,
@@ -125,6 +125,7 @@ def test_request_headers(mock_get_and_post):
         assert headers[constants.HEADER_SOURCE] == source
         assert headers[constants.HEADER_USER] == user
         assert headers[constants.HEADER_SESSION] == ""
+        assert headers[constants.HEADER_TRANSACTION] is None
         assert headers[constants.HEADER_TIMEZONE] == timezone
         assert headers[constants.HEADER_CLIENT_CAPABILITIES] == "PARAMETRIC_DATETIME"
         assert headers[accept_encoding_header] == accept_encoding_value
@@ -135,7 +136,8 @@ def test_request_headers(mock_get_and_post):
             "catalog1=NONE,"
             "catalog2=" + urllib.parse.quote("ROLE{catalog2_role}")
         )
-        assert len(headers.keys()) == 11
+        assert headers["User-Agent"] == f"{constants.CLIENT_NAME}/{__version__}"
+        assert len(headers.keys()) == 12
 
     req.post("URL")
     _, post_kwargs = post.call_args

--- a/trino/client.py
+++ b/trino/client.py
@@ -62,6 +62,7 @@ from tzlocal import get_localzone_name  # type: ignore
 
 import trino.logging
 from trino import constants, exceptions
+from trino._version import __version__
 
 __all__ = ["ClientSession", "TrinoQuery", "TrinoRequest", "PROXIES"]
 
@@ -447,7 +448,7 @@ class TrinoRequest(object):
 
     @property
     def http_headers(self) -> Dict[str, str]:
-        headers = {}
+        headers = requests.structures.CaseInsensitiveDict()
 
         headers[constants.HEADER_CATALOG] = self._client_session.catalog
         headers[constants.HEADER_SCHEMA] = self._client_session.schema
@@ -455,6 +456,7 @@ class TrinoRequest(object):
         headers[constants.HEADER_USER] = self._client_session.user
         headers[constants.HEADER_TIMEZONE] = self._client_session.timezone
         headers[constants.HEADER_CLIENT_CAPABILITIES] = 'PARAMETRIC_DATETIME'
+        headers["user-agent"] = f"{constants.CLIENT_NAME}/{__version__}"
         if len(self._client_session.roles.values()):
             headers[constants.HEADER_ROLE] = ",".join(
                 # ``name`` must not contain ``=``

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -26,6 +26,8 @@ HTTPS = "https"
 
 URL_STATEMENT_PATH = "/v1/statement"
 
+CLIENT_NAME = "Trino Python Client"
+
 HEADER_CATALOG = "X-Trino-Catalog"
 HEADER_SCHEMA = "X-Trino-Schema"
 HEADER_SOURCE = "X-Trino-Source"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino introduces some breaking changes for old client versions but there is no way to find out the client version of our users to warn them before upgrading to a newer version since the python client is using the default user agent from `requests` that results `python-requests/2.31.0`. However, the JDBC driver [sets](https://github.com/trinodb/trino/blob/423/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java#L123) a more descriptive user agent header value such as `Trino JDBC Driver/371` that helps us to identify users with outdated client versions.

This PR aims to specify the user agent to pass the current driver version to the coordinator to be logged later in query created and completed events as [`io.trino.spi.eventlistener.QueryContext.userAgent`](https://github.com/trinodb/trino/blob/423/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java#L39C1-L39C1).

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This change will allow us to spot outdated clients accessing our Trino cluster.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Add Trino Python Client version to User-Agent header. ({issue}`411`)
```
