### PR TITLE
fix fetchall returns remaining cursor

### DIFF
--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -1328,6 +1328,15 @@ def test_select_tpch_1000(trino_connection):
     assert len(rows) == 1000
 
 
+def test_fetch_cursor(trino_connection):
+    cur = trino_connection.cursor()
+    cur.execute("SELECT * FROM tpch.sf1.customer LIMIT 1000")
+    for _ in range(100):
+        cur.fetchone()
+    assert len(cur.fetchmany(400)) == 400
+    assert len(cur.fetchall()) == 500
+
+
 def test_cancel_query(trino_connection):
     cur = trino_connection.cursor()
     cur.execute("SELECT * FROM tpch.sf1.customer")

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -23,6 +23,7 @@ import math
 import uuid
 from collections import OrderedDict
 from decimal import Decimal
+from itertools import islice
 from threading import Lock
 from time import time
 from typing import Any, Dict, List, NamedTuple, Optional  # NOQA for mypy types
@@ -661,14 +662,7 @@ class Cursor(object):
         if size is None:
             size = self.arraysize
 
-        result = []
-        for _ in range(size):
-            row = self.fetchone()
-            if row is None:
-                break
-            result.append(row)
-
-        return result
+        return list(islice(iter(self.fetchone, None), size))
 
     def describe(self, sql: str) -> List[DescribeOutput]:
         """
@@ -696,7 +690,7 @@ class Cursor(object):
         return self._query.result
 
     def fetchall(self) -> List[List[Any]]:
-        return list(self.genall())
+        return list(iter(self.fetchone, None))
 
     def cancel(self):
         if self._query is None:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

fixes #414

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix fetchall doesn't respect the cursor position ({issue}`414`)
```
