### PR TITLE
Check cursor _query is None before columns

### DIFF
--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -309,3 +309,9 @@ def test_hostname_parsing():
     assert only_hostname_with_path.host == "mytrinoserver.domain/some_path"
     assert only_hostname_with_path.port == 8080
     assert only_hostname_with_path.http_scheme == constants.HTTP
+
+
+def test_description_is_none_when_cursor_is_not_executed():
+    connection = Connection("sample_trino_cluster:443")
+    cursor = connection.cursor()
+    assert hasattr(cursor, 'description')

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -376,7 +376,7 @@ class Cursor(object):
 
     @property
     def description(self) -> List[ColumnDescription]:
-        if self._query.columns is None:
+        if self._query is None or self._query.columns is None:
             return None
 
         # [ (name, type_code, display_size, internal_size, precision, scale, null_ok) ]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes an issue where if `cursor.description` is called before `execute`, then it returns `AttributeError` for `columns`. This make this client not work with [Ray Data](https://github.com/ray-project/ray/blob/master/python/ray/data/datasource/sql_datasource.py#L71-L81) because it checks if `description` exists.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Guard against error state when calling a function


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
