### PR TITLE
Default to https scheme when port is 443 (sqlalchemy)

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -39,7 +39,14 @@ class TestTrinoDialect:
                 )),
                 'trino://user@localhost:443/?source=trino-sqlalchemy',
                 list(),
-                dict(host="localhost", port=443, catalog="system", user="user", source="trino-sqlalchemy"),
+                dict(
+                    host="localhost",
+                    port=443,
+                    catalog="system",
+                    user="user",
+                    source="trino-sqlalchemy",
+                    http_scheme="https",
+                ),
             ),
             (
                 make_url(trino_url(

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -91,6 +91,8 @@ class TrinoDialect(DefaultDialect):
 
         if url.port:
             kwargs["port"] = url.port
+            if url.port == 443:
+                kwargs["http_scheme"] = "https"
 
         db_parts = (url.database or "system").split("/")
         if len(db_parts) == 1:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Attempting to use `sqlalchemy` with HTTPS scheme and default port `443` results in a `TrinoConnectionError: RemoteDisconnected('Remote end closed connection without response')` as the underlying dialect's `http_scheme` is set to `http` not `https`. This PR will automatically set the `http_scheme` to `https` which alleviates the connection issue.

Trino server: 430
Trino client: 0.327.0
SQLAlchemy: 2.0.22

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Using sqlalchemy with a Trino server accessed via an `https` endpoint and no custom port results in a connection error. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
