### PR TITLE
Only set log level for the root logger

### DIFF
--- a/trino/logging.py
+++ b/trino/logging.py
@@ -11,12 +11,21 @@
 # limitations under the License.
 
 import logging
+from typing import Optional
 
 LEVEL = logging.INFO
 
 
 # TODO: provide interface to use ``logging.dictConfig``
-def get_logger(name: str, log_level: int = LEVEL) -> logging.Logger:
+def get_logger(name: str, log_level: Optional[int] = None) -> logging.Logger:
     logger = logging.getLogger(name)
-    logger.setLevel(log_level)
+    # We must not call setLevel by default except on the root logger otherwise
+    # we cannot change log levels for all modules by changing level of the root
+    # logger
+    if log_level is not None:
+        logger.setLevel(log_level)
     return logger
+
+
+# set default log level to LEVEL
+trino_root_logger = get_logger('trino', LEVEL)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Before this change we called `setLevel` on each logger with level set to INFO. This meant that it was not possible to change log level for all child modules by doing something like
`logging.getLogger('trino').setLevel(logging.DEBUG)` because the child loggers had explicit levels set already. It instead required us to change log levels for each module (`trino.client`, `trino.dbapi`, `trino.auth` etc.) separately.

After this change only the root logger `trino` has a default level set. Other child loggers inherit from it. So now the default log level for all modules can be changed by doing
`logging.getLogger('trino').setLevel(logging.DEBUG)` for example.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make it easy to configure log level for all modules at once.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Make it possible to configure log level for all modules via the root logger. ({issue}`424`)
```

Fixes #424