### PR TITLE
Fix mapping of MAP types with boolean or integer keys

### DIFF
--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -799,11 +799,9 @@ def test_map(trino_connection):
         SqlTest(trino_connection)
         .add_field(sql="CAST(null AS MAP(VARCHAR, INTEGER))", python=None)
         .add_field(sql="MAP()", python={})
-        # TODO: boolean map keys get returned as strings
-        # .add_field(sql="MAP(ARRAY[true, false], ARRAY[false, true])", python={True: False, False: True})
-        # .add_field(sql="MAP(ARRAY[true, false], ARRAY[true, null])", python={True: True, False: None})
-        # TODO: integer map keys get returned as strings
-        # .add_field(sql="MAP(ARRAY[1, 2], ARRAY[1, null])", python={1: 1, 2: None})
+        .add_field(sql="MAP(ARRAY[true, false], ARRAY[false, true])", python={True: False, False: True})
+        .add_field(sql="MAP(ARRAY[true, false], ARRAY[true, null])", python={True: True, False: None})
+        .add_field(sql="MAP(ARRAY[1, 2], ARRAY[1, null])", python={1: 1, 2: None})
         .add_field(sql="MAP("
                        "ARRAY[CAST('NaN' AS REAL), CAST('-Infinity' AS REAL), CAST(3.4028235E38 AS REAL), CAST(1.4E-45 AS REAL), CAST('Infinity' AS REAL), CAST(1 AS REAL)], "  # noqa: E501
                        "ARRAY[CAST('NaN' AS REAL), CAST('-Infinity' AS REAL), CAST(3.4028235E38 AS REAL), CAST(1.4E-45 AS REAL), CAST('Infinity' AS REAL), null])",  # noqa: E501

--- a/trino/mapper.py
+++ b/trino/mapper.py
@@ -74,6 +74,13 @@ class DecimalValueMapper(ValueMapper[Decimal]):
         return Decimal(value)
 
 
+class StringValueMapper(ValueMapper[str]):
+    def map(self, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
 class BinaryValueMapper(ValueMapper[bytes]):
     def map(self, value) -> Optional[bytes]:
         if value is None:
@@ -252,8 +259,12 @@ class RowMapperFactory:
             return DoubleValueMapper()
         if col_type == 'decimal':
             return DecimalValueMapper()
+        if col_type in {'varchar', 'char'}:
+            return StringValueMapper()
         if col_type == 'varbinary':
             return BinaryValueMapper()
+        if col_type == 'json':
+            return StringValueMapper()
         if col_type == 'date':
             return DateValueMapper()
         if col_type == 'time':


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix mapping of MAP types with boolean or integer keys.

This is on top of https://github.com/trinodb/trino-python-client/pull/440 so only last 3 commits need to be reviewed.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Fix mapping of MAP types with boolean or integer keys.
```
