### PR TITLE
Fixed OAuth2Authentication redirect_auth_url_handler callback not firing

### DIFF
--- a/trino/auth.py
+++ b/trino/auth.py
@@ -320,7 +320,7 @@ class _OAuth2TokenBearer(AuthBase):
             raise exceptions.TrinoAuthError(f"Error: header info didn't match {auth_info}")
 
         auth_info_headers = parse_dict_header(
-            _OAuth2TokenBearer._BEARER_PREFIX.sub("", auth_info, count=1))  # type: ignore
+            _OAuth2TokenBearer._BEARER_PREFIX.sub("", auth_info))  # type: ignore
 
         auth_server = auth_info_headers.get('x_redirect_server')
         token_server = auth_info_headers.get('x_token_server')


### PR DESCRIPTION
Remove the Bearer from x_redirect_server, with the count remove only the first coincidence and it make fails the redirect auth url callback.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
* Fix the non firing auth url callback issue when oauth2 is used ({issue}`444`)
```
