### PR TITLE
Add support for MAP type to SQLAlchemy dialect

### DIFF
--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -246,6 +246,13 @@ class TrinoTypeCompiler(compiler.GenericTypeCompiler):
     def visit_JSON(self, type_, **kw):
         return 'JSON'
 
+    def visit_MAP(self, type_, **kw):
+        # the key and value types themselves need to be processed otherwise sqltypes.MAP(Float, Float) will get
+        # rendered as MAP(FLOAT, FLOAT) instead of MAP(REAL, REAL) or MAP(DOUBLE, DOUBLE)
+        key_type = self.process(type_.key_type, **kw)
+        value_type = self.process(type_.value_type, **kw)
+        return f'MAP({key_type}, {value_type})'
+
 
 class TrinoIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = RESERVED_WORDS


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Adds support for MAP type to SQLA dialect.
Fixes https://github.com/trinodb/trino-python-client/issues/397
Supersedes https://github.com/trinodb/trino-python-client/pull/398

This preserves commit authorship from https://github.com/trinodb/trino-python-client/pull/398.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Add support for `MAP` to SQLAlchemy dialect.
```
