### PR TITLE
Add GSSAPIAuthentication authentication class.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libkrb5-dev
           pip install wheel
-          pip install .[tests] sqlalchemy${{ matrix.sqlalchemy }}
+          pip install .[tests,gssapi] sqlalchemy${{ matrix.sqlalchemy }}
       - name: Run tests
         run: |
           pytest -s tests/

--- a/README.md
+++ b/README.md
@@ -326,6 +326,43 @@ the [`Kerberos` authentication type](https://trino.io/docs/current/security/kerb
     )
     ```
 
+### GSSAPI authentication
+
+The `GSSAPIAuthentication` class can be used to connect to a Trino cluster configured with
+the [`Kerberos` authentication type](https://trino.io/docs/current/security/kerberos.html):
+
+It follows the interface for `KerberosAuthentication`, but is using
+[requests-gssapi](https://github.com/pythongssapi/requests-gssapi), instead of [requests-kerberos](https://github.com/requests/requests-kerberos) under the hood.
+
+- DBAPI
+
+    ```python
+    from trino.dbapi import connect
+    from trino.auth import GSSAPIAuthentication
+
+    conn = connect(
+        user="<username>",
+        auth=GSSAPIAuthentication(...),
+        http_scheme="https",
+        ...
+    )
+    ```
+
+- SQLAlchemy
+
+    ```python
+    from sqlalchemy import create_engine
+    from trino.auth import GSSAPIAuthentication
+
+    engine = create_engine(
+        "trino://<username>@<host>:<port>/<catalog>",
+        connect_args={
+            "auth": GSSAPIAuthentication(...),
+            "http_scheme": "https",
+        }
+    )
+    ```
+
 ## User impersonation
 
 In the case where user who submits the query is not the same as user who authenticates to Trino server (e.g in Superset),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(here, "README.md"), "r", "utf-8") as f:
     readme = f.read()
 
 kerberos_require = ["requests_kerberos"]
-gssapi_require = ["requests_kerberos"]
+gssapi_require = ["requests_gssapi"]
 sqlalchemy_require = ["sqlalchemy >= 1.3"]
 external_authentication_token_cache_require = ["keyring"]
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open(os.path.join(here, "README.md"), "r", "utf-8") as f:
     readme = f.read()
 
 kerberos_require = ["requests_kerberos"]
+gssapi_require = ["requests_kerberos"]
 sqlalchemy_require = ["sqlalchemy >= 1.3"]
 external_authentication_token_cache_require = ["keyring"]
 
@@ -86,6 +87,7 @@ setup(
     extras_require={
         "all": all_require,
         "kerberos": kerberos_require,
+        "gssapi": gssapi_require,
         "sqlalchemy": sqlalchemy_require,
         "tests": tests_require,
         "external-authentication-token-cache": external_authentication_token_cache_require,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -885,7 +885,7 @@ class RetryRecorder(object):
 
 
 @pytest.mark.parametrize(
-    "auth_method, retry_exception",
+    "auth_class, retry_exception_class",
     [
         (KerberosAuthentication, KerberosExchangeError),
         (GSSAPIAuthentication, SPNEGOExchangeError),


### PR DESCRIPTION
## Description

Add yet another Authentication method, via `requests-gssapi`. The provided class, `GSSAPIAuthentication` is complete copy-paste of `KerberosAuthentication`, but uses a much nicer library (`requests-gssapi`) underneath.

## Non-technical explanation

Added support for alternative method of kerberos authentication.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Add requests-gssapi based authentication via `GSSAPIAuthentication`. ({issue}`454`)
```
