### PR TITLE
Support object as value in extra_credential

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -486,7 +486,8 @@ class TrinoRequest(object):
             # extra credential value is encoded per spec (application/x-www-form-urlencoded MIME format)
             headers[constants.HEADER_EXTRA_CREDENTIAL] = \
                 ", ".join(
-                    [f"{tup[0]}={urllib.parse.quote_plus(tup[1])}" for tup in self._client_session.extra_credential])
+                    [f"{tup[0]}={urllib.parse.quote_plus(str(tup[1]))}"
+                     for tup in self._client_session.extra_credential])
 
         return headers
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I want `extra_credential` to accept an object as a value. This is helpful because it allows pass through of short lived tokens (JWT or otherwise) that can be refreshed by the client without having to generate a new engine/client object.

Presently this is not possible because `parse_quote` does a [check](https://github.com/python/cpython/blob/de1428f8c234a8731ced99cbfe5cd6c5c719e31d/Lib/urllib/parse.py#L916) on the object type.

Therefore it is necessary to call `str()` on the `extra_credential` value during serialisation.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Support object as value in `extra_credential` to support refreshing tokens.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Support object as value in `extra_credential` to support refreshing tokens.
```
