### PR TITLE
Add visit_try_cast to sqlalchemy compiler

### DIFF
--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -151,3 +151,14 @@ def test_ignore_nulls(dialect, function, element):
     assert str(query) == \
            f'SELECT {function}("table".id) OVER (PARTITION BY "table".name) AS window ' \
            f'\nFROM "table"'
+
+
+@pytest.mark.skipif(
+    sqlalchemy_version() < "2.0",
+    reason="ImportError: cannot import name 'try_cast' from 'sqlalchemy'"
+)
+def test_try_cast(dialect):
+    from sqlalchemy import try_cast
+    statement = select(try_cast(table_without_catalog.c.id, String))
+    query = statement.compile(dialect=dialect)
+    assert str(query) == 'SELECT try_cast("table".id as VARCHAR) AS id \nFROM "table"'

--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -175,6 +175,9 @@ class TrinoSQLCompiler(compiler.SQLCompiler):
             compiled += ' IGNORE NULLS'
         return compiled
 
+    def visit_try_cast(self, element, **kw):
+        return f"try_cast({self.process(element.clause, **kw)} as {self.process(element.typeclause, **kw)})"
+
 
 class TrinoDDLCompiler(compiler.DDLCompiler):
     pass


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
I have added a `visit_try_cast()` method to `trino.sqlalchemy.compiler.TrinoSQLCompiler`. This fixes [issue 473](https://github.com/trinodb/trino-python-client/issues/473).




<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
This allows Trino's [`try_cast()`](https://trino.io/docs/current/functions/conversion.html#try_cast) to be used in SQLAlchemy.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
