### PR TITLE
Shard long JWT token on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ tests_require = all_require + gssapi_require + [
     "pre-commit",
     "black",
     "isort",
+    "keyring"
 ]
 
 setup(

--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -119,7 +119,7 @@ def test_token_retrieved_once_per_auth_instance(sample_post_response_data, sampl
         conn2.cursor().execute("SELECT 2")
         conn2.cursor().execute("SELECT 3")
 
-    assert len(_get_token_requests(challenge_id)) == 2
+    assert len(_get_token_requests(challenge_id)) == 1
 
 
 @httprettified

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -20,6 +20,7 @@ DEFAULT_SCHEMA: Optional[str] = None
 DEFAULT_AUTH: Optional[Any] = None
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_REQUEST_TIMEOUT: float = 30.0
+MAX_NT_PASSWORD_SIZE: int = 1280
 
 HTTP = "http"
 HTTPS = "https"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, storing a long JWT token on Windows triggers the following error:
```
During handling of the above exception, another exception occurred:
....
  File "\lib\site-packages\trino\auth.py", line 403, in _authenticate
    self._attempt_oauth(response, **kwargs)
  File "\lib\site-packages\trino\auth.py", line 449, in _attempt_oauth
    self._store_token_to_cache(key, token)
  File "\lib\site-packages\trino\auth.py", line 498, in _store_token_to_cache
    self._token_cache.store_token_to_cache(key, token)
  File "\lib\site-packages\trino\auth.py", line 360, in store_token_to_cache
_password
    get_keyring().set_password(service_name, username, password)
  File "\lib\site-packages\keyring\backends\Windows.py", line 128, in set_password
    self._set_password(service, username, str(password))
  File "\lib\site-packages\keyring\backends\Windows.py", line 139, in _set_password
    win32cred.CredWrite(credential, 0)
  File "\lib\site-packages\win32ctypes\pywin32\win32cred.py", line 35, in CredWrite
    _authentication._CredWrite(c_pcreds, 0)
  File "\lib\contextlib.py", line 137, in __exit__
    self.gen.throw(typ, value, traceback)
  File "\lib\site-packages\win32ctypes\pywin32\pywintypes.py", line 37, in pywin32error
    raise error(exception.winerror, exception.function, exception.strerror)
win32ctypes.pywin32.pywintypes.error: (1783, 'CredWrite', 'The stub received bad data')
```

This pull request addresses the issue by introducing sharding for long JWT tokens on Windows, ensuring they are stored correctly without causing the above error.

Based on https://github.com/databricks/dbt-databricks/pull/599

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
