### PR TITLE
Fix `cert` and `key` kwargs parsing from URL in sqlachemy's `create_connect_args` function

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -298,6 +298,23 @@ def test_trino_connection_certificate_auth():
     assert cparams['auth']._key == key
 
 
+def test_trino_connection_certificate_auth_cert_and_key_required():
+    dialect = TrinoDialect()
+    cert = '/path/to/cert.pem'
+    key = '/path/to/key.pem'
+    url = make_url(f'trino://host/?cert={cert}')
+    _, cparams = dialect.create_connect_args(url)
+
+    assert 'http_scheme' not in cparams
+    assert 'auth' not in cparams
+
+    url = make_url(f'trino://host/?key={key}')
+    _, cparams = dialect.create_connect_args(url)
+
+    assert 'http_scheme' not in cparams
+    assert 'auth' not in cparams
+
+
 def test_trino_connection_oauth2_auth():
     dialect = TrinoDialect()
     url = make_url('trino://host/?externalAuthentication=true')

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -131,7 +131,7 @@ class TrinoDialect(DefaultDialect):
             kwargs["http_scheme"] = "https"
             kwargs["auth"] = JWTAuthentication(unquote_plus(url.query["access_token"]))
 
-        if "cert" and "key" in url.query:
+        if "cert" in url.query and "key" in url.query:
             kwargs["http_scheme"] = "https"
             kwargs["auth"] = CertificateAuthentication(unquote_plus(url.query['cert']), unquote_plus(url.query['key']))
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Previous version of code contained an always true condition that may lead to unintended behaviour. This bug was captured by flake8 linter, so it may be a good idea to include it as a part of CI process.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix `cert` and `key` kwargs parsing from URL in sqlachemy's `create_connect_args` function
```
