### PR TITLE
Fix www-authenticate header parsing bug when refreshing tokens

### DIFF
--- a/tests/unit/oauth_test_utils.py
+++ b/tests/unit/oauth_test_utils.py
@@ -54,11 +54,25 @@ class PostStatementCallback:
         if authorization and authorization.replace("Bearer ", "") in self.tokens:
             return [200, response_headers, json.dumps(self.sample_post_response_data)]
         elif self.redirect_server is None and self.token_server is not None:
-            return [401, {'Www-Authenticate': f'Bearer x_token_server="{self.token_server}"',
-                          'Basic realm': '"Trino"'}, ""]
-        return [401, {'Www-Authenticate': f'Bearer x_redirect_server="{self.redirect_server}", '
-                                          f'x_token_server="{self.token_server}"',
-                      'Basic realm': '"Trino"'}, ""]
+            return [401,
+                    {
+                        'Www-Authenticate': (
+                            'Bearer realm="Trino", token_type="JWT", '
+                            f'Bearer x_token_server="{self.token_server}"'
+                        ),
+                        'Basic realm': '"Trino"'
+                    },
+                    ""]
+        return [401,
+                {
+                    'Www-Authenticate': (
+                        'Bearer realm="Trino", token_type="JWT", '
+                        f'Bearer x_redirect_server="{self.redirect_server}", '
+                        f'x_token_server="{self.token_server}"'
+                    ),
+                    'Basic realm': '"Trino"'
+                },
+                ""]
 
 
 class GetTokenCallback:

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -459,7 +459,7 @@ class _OAuth2TokenBearer(AuthBase):
         auth_info_headers = self._parse_authenticate_header(auth_info)
 
         auth_server = auth_info_headers.get('bearer x_redirect_server', auth_info_headers.get('x_redirect_server'))
-        token_server = auth_info_headers.get('x_token_server')
+        token_server = auth_info_headers.get('bearer x_token_server', auth_info_headers.get('x_token_server'))
         if token_server is None:
             raise exceptions.TrinoAuthError("Error: header info didn't have x_token_server")
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR applies a minimal change to fix the issue where the OAuth refresh token flow results in the "Header info didn't have x_token_server" error:
```
trino.exceptions.TrinoAuthError: Error: header info didn't have x_token_server
```

This error was introduced in #467. The regression was not captured by the test `test_oauth2_refresh_token_flow`; Trino returns multi-valued `Www-Authenticate` headers while `PostStatementCallback` does not, and the new parsing logic does not handle this appropriately. This PR also updates the test.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This PR fixes the issue where Trino returns "Header info didn't have x_token_server" after some time and starts working again after a longer time. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fixes "header info didn't have x_token_server" error. ({issue}`484`)
```
