### PR TITLE
Drop support for end-of-life Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           "3.10",
           "3.11",
           "3.12",
+          "3.13",
           "pypy-3.9",
           "pypy-3.10",
         ]
@@ -56,11 +57,11 @@ jobs:
         ]
         include:
           # Test with older Trino versions for backward compatibility
-          - { python: "3.12", trino: "351", sqlalchemy: "~=1.4.0" }  # first Trino version
+          - { python: "3.13", trino: "351", sqlalchemy: "~=1.4.0" }  # first Trino version
           # Test with sqlalchemy 1.3
-          - { python: "3.12", trino: "latest", sqlalchemy: "~=1.3.0" }
+          - { python: "3.13", trino: "latest", sqlalchemy: "~=1.3.0" }
           # Test with sqlalchemy 2.0
-          - { python: "3.12", trino: "latest", sqlalchemy: "~=2.0.0" }
+          - { python: "3.13", trino: "latest", sqlalchemy: "~=2.0.0" }
     env:
       TRINO_VERSION: "${{ matrix.trino }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          "3.8",
           "3.9",
           "3.10",
           "3.11",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for [Trino](https://trino.io/), a distributed SQL engine for interactive and batch big data processing.
 Provides a low-level client and a DBAPI 2.0 implementation and a SQLAlchemy adapter.
-It supports Python>=3.8 and PyPy.
+It supports Python>=3.9 and PyPy.
 
 [![Build Status](https://github.com/trinodb/trino-python-client/workflows/ci/badge.svg)](https://github.com/trinodb/trino-python-client/actions?query=workflow%3Aci+event%3Apush+branch%3Amaster)
 [![Trino Slack](https://img.shields.io/static/v1?logo=slack&logoColor=959DA5&label=Slack&labelColor=333a41&message=join%20conversation&color=3AC358)](https://trino.io/slack.html)

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database :: Front-Ends",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -79,9 +78,8 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database :: Front-Ends",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
-        "backports.zoneinfo;python_version<'3.9'",
         "python-dateutil",
         "pytz",
         # requests CVE https://github.com/advisories/GHSA-j8r2-6x86-q33q

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -15,11 +15,7 @@ import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from typing import Tuple
-
-try:
-    from zoneinfo import ZoneInfo
-except ModuleNotFoundError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import pytest
 import requests

--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -3,11 +3,7 @@ import re
 import uuid
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from decimal import Decimal
-
-try:
-    from zoneinfo import ZoneInfo
-except ModuleNotFoundError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import pytest
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -18,6 +18,7 @@ from contextlib import nullcontext as does_not_raise
 from typing import Any, Dict, Optional
 from unittest import TestCase, mock
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfoNotFoundError
 
 import gssapi
 import httpretty
@@ -58,11 +59,6 @@ from trino.client import (
     _retry_with,
     _RetryWithExponentialBackoff,
 )
-
-try:
-    from zoneinfo import ZoneInfoNotFoundError  # type: ignore
-except ModuleNotFoundError:
-    from backports.zoneinfo._common import ZoneInfoNotFoundError  # type: ignore
 
 
 @mock.patch("trino.client.TrinoRequest.http")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py39,py310,py311
 
 [testenv]
 extras = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311
+envlist = py39,py310,py311,py312,py313
 
 [testenv]
 extras = tests

--- a/trino/client.py
+++ b/trino/client.py
@@ -47,13 +47,7 @@ from datetime import datetime
 from email.utils import parsedate_to_datetime
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
-
-from trino.mapper import RowMapper, RowMapperFactory
-
-try:
-    from zoneinfo import ZoneInfo
-except ModuleNotFoundError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import requests
 from tzlocal import get_localzone_name  # type: ignore
@@ -61,6 +55,7 @@ from tzlocal import get_localzone_name  # type: ignore
 import trino.logging
 from trino import constants, exceptions
 from trino._version import __version__
+from trino.mapper import RowMapper, RowMapperFactory
 
 __all__ = ["ClientSession", "TrinoQuery", "TrinoRequest", "PROXIES"]
 

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -27,11 +27,7 @@ from threading import Lock
 from time import time
 from typing import Any, Dict, List, NamedTuple, Optional  # NOQA for mypy types
 from urllib.parse import urlparse
-
-try:
-    from zoneinfo import ZoneInfo
-except ModuleNotFoundError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import trino.client
 import trino.exceptions

--- a/trino/mapper.py
+++ b/trino/mapper.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 import abc
 import base64
-import sys
 import uuid
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from decimal import Decimal
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import trino.exceptions
 from trino.types import (


### PR DESCRIPTION
Drop support for end-of-life Python 3.8
Remove backports.zoneinfo dependency<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Drop support for end-of-life Python 3.8 and add support for Python 3.13. ({issue}`issuenumber`)
```
