### PR TITLE
Fix parsing authentication header

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -543,13 +543,14 @@ def test_oauth2_authentication_missing_headers(header, error):
     'Bearer x_redirect_server="{redirect_server}", x_token_server="{token_server}", Basic realm="Trino"',
     'Basic realm="Trino", Bearer realm="Trino", token_type="JWT", Bearer x_redirect_server="{redirect_server}", '
     'x_token_server="{token_server}"'
+    'Bearer x_redirect_server="{redirect_server}",x_token_server="{token_server}",additional_challenge',
 ])
 @httprettified
 def test_oauth2_header_parsing(header, sample_post_response_data):
     token = str(uuid.uuid4())
     challenge_id = str(uuid.uuid4())
 
-    redirect_server = f"{REDIRECT_RESOURCE}/{challenge_id}"
+    redirect_server = f"{REDIRECT_RESOURCE}/{challenge_id}?role=test"
     token_server = f"{TOKEN_RESOURCE}/{challenge_id}"
 
     # noinspection PyUnusedLocal

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -546,17 +546,17 @@ class _OAuth2TokenBearer(AuthBase):
 
     @staticmethod
     def _parse_authenticate_header(header: str) -> Dict[str, str]:
-        split_challenge = header.split(" ", 1)
-        trimmed_challenge = split_challenge[1] if len(split_challenge) > 1 else ""
+        logger.debug(f"Authentication header: {header}")
+        components = header.split(",")
         auth_info_headers = {}
 
-        for item in trimmed_challenge.split(","):
-            comps = item.split("=")
-            if len(comps) == 2:
-                key = comps[0].strip(' "')
-                value = comps[1].strip(' "')
-                if key:
-                    auth_info_headers[key.lower()] = value
+        for component in components:
+            component = component.strip()
+            if "=" in component:
+                key, value = component.split("=", 1)
+                if value[0] == '"' and value[-1] == '"':
+                    value = value[1:-1]
+                auth_info_headers[key.lower()] = value
         return auth_info_headers
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently the function to parse the authorization header doesn't support urls containing parameters. This PR addresses this.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:


```markdown
* Fix authentication parsing to allow urls containing url parameters
```
