### PR TITLE
Replace "isort" with "reorder-python-imports"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,12 @@ repos:
       - id: "mypy"
         name: "Python: types"
 
-  - repo: "https://github.com/PyCQA/isort"
-    rev: "5.13.2"
+  - repo: "https://github.com/asottile/reorder-python-imports"
+    rev: "v3.14.0"
     hooks:
-      - id: "isort"
+      - id: "reorder-python-imports"
         name: "Python: imports"
-        args: ["--profile", "black"]
+        args: ["--py39-plus"]
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: "v5.0.0"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,12 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 from codecs import open
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
 
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 about: Dict[str, Any] = {}
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import socket
 import subprocess
@@ -20,7 +19,9 @@ from uuid import uuid4
 import pytest
 
 import trino.logging
-from trino.client import ClientSession, TrinoQuery, TrinoRequest
+from trino.client import ClientSession
+from trino.client import TrinoQuery
+from trino.client import TrinoRequest
 from trino.constants import DEFAULT_PORT
 
 logger = trino.logging.get_logger(__name__)

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -12,7 +12,11 @@
 import math
 import time as t
 import uuid
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
 from decimal import Decimal
 from typing import Tuple
 from zoneinfo import ZoneInfo
@@ -24,8 +28,12 @@ from tzlocal import get_localzone_name  # type: ignore
 import trino
 from tests.integration.conftest import trino_version
 from trino import constants
-from trino.dbapi import Cursor, DescribeOutput, TimeBoundLRUCache
-from trino.exceptions import NotSupportedError, TrinoQueryError, TrinoUserError
+from trino.dbapi import Cursor
+from trino.dbapi import DescribeOutput
+from trino.dbapi import TimeBoundLRUCache
+from trino.exceptions import NotSupportedError
+from trino.exceptions import TrinoQueryError
+from trino.exceptions import TrinoUserError
 from trino.transaction import IsolationLevel
 
 

--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -15,12 +15,16 @@ from decimal import Decimal
 
 import pytest
 import sqlalchemy as sqla
-from sqlalchemy.sql import and_, not_, or_
+from sqlalchemy.sql import and_
+from sqlalchemy.sql import not_
+from sqlalchemy.sql import or_
 from sqlalchemy.types import ARRAY
 
 from tests.integration.conftest import trino_version
 from tests.unit.conftest import sqlalchemy_version
-from trino.sqlalchemy.datatype import JSON, MAP, ROW
+from trino.sqlalchemy.datatype import JSON
+from trino.sqlalchemy.datatype import MAP
+from trino.sqlalchemy.datatype import ROW
 
 
 @pytest.fixture

--- a/tests/integration/test_types_integration.py
+++ b/tests/integration/test_types_integration.py
@@ -1,7 +1,12 @@
 import math
 import re
 import uuid
-from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
+from datetime import tzinfo
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,8 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/oauth_test_utils.py
+++ b/tests/unit/oauth_test_utils.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import json
 import re
 import uuid

--- a/tests/unit/sqlalchemy/conftest.py
+++ b/tests/unit/sqlalchemy/conftest.py
@@ -12,7 +12,11 @@
 import pytest
 from sqlalchemy.sql.sqltypes import ARRAY
 
-from trino.sqlalchemy.datatype import MAP, ROW, TIME, TIMESTAMP, SQLType
+from trino.sqlalchemy.datatype import MAP
+from trino.sqlalchemy.datatype import ROW
+from trino.sqlalchemy.datatype import SQLType
+from trino.sqlalchemy.datatype import TIME
+from trino.sqlalchemy.datatype import TIMESTAMP
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -10,9 +10,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from sqlalchemy import Column, Integer, MetaData, String, Table, func, insert, select
+from sqlalchemy import Column
+from sqlalchemy import func
+from sqlalchemy import insert
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import select
+from sqlalchemy import String
+from sqlalchemy import Table
 from sqlalchemy.schema import CreateTable
-from sqlalchemy.sql import column, table
+from sqlalchemy.sql import column
+from sqlalchemy.sql import table
 
 from tests.unit.conftest import sqlalchemy_version
 from trino.sqlalchemy.dialect import TrinoDialect

--- a/tests/unit/sqlalchemy/test_datatype_parse.py
+++ b/tests/unit/sqlalchemy/test_datatype_parse.py
@@ -11,11 +11,19 @@
 # limitations under the License.
 import pytest
 from sqlalchemy.exc import UnsupportedCompilationError
-from sqlalchemy.sql.sqltypes import ARRAY, CHAR, DATE, DECIMAL, INTEGER, VARCHAR
+from sqlalchemy.sql.sqltypes import ARRAY
+from sqlalchemy.sql.sqltypes import CHAR
+from sqlalchemy.sql.sqltypes import DATE
+from sqlalchemy.sql.sqltypes import DECIMAL
+from sqlalchemy.sql.sqltypes import INTEGER
+from sqlalchemy.sql.sqltypes import VARCHAR
 from sqlalchemy.sql.type_api import TypeEngine
 
 from trino.sqlalchemy import datatype
-from trino.sqlalchemy.datatype import MAP, ROW, TIME, TIMESTAMP
+from trino.sqlalchemy.datatype import MAP
+from trino.sqlalchemy.datatype import ROW
+from trino.sqlalchemy.datatype import TIME
+from trino.sqlalchemy.datatype import TIMESTAMP
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -1,17 +1,19 @@
-from typing import Any, Dict, List
+from typing import Any
+from typing import Dict
+from typing import List
 from unittest import mock
 
 import pytest
-from sqlalchemy.engine.url import URL, make_url
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.engine.url import URL
 
-from trino.auth import BasicAuthentication, OAuth2Authentication
+from trino.auth import BasicAuthentication
+from trino.auth import OAuth2Authentication
 from trino.dbapi import Connection
 from trino.sqlalchemy import URL as trino_url
-from trino.sqlalchemy.dialect import (
-    CertificateAuthentication,
-    JWTAuthentication,
-    TrinoDialect,
-)
+from trino.sqlalchemy.dialect import CertificateAuthentication
+from trino.sqlalchemy.dialect import JWTAuthentication
+from trino.sqlalchemy.dialect import TrinoDialect
 from trino.transaction import IsolationLevel
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -15,8 +15,11 @@ import time
 import urllib
 import uuid
 from contextlib import nullcontext as does_not_raise
-from typing import Any, Dict, Optional
-from unittest import TestCase, mock
+from typing import Any
+from typing import Dict
+from typing import Optional
+from unittest import mock
+from unittest import TestCase
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfoNotFoundError
 
@@ -31,34 +34,29 @@ from requests_kerberos.exceptions import KerberosExchangeError
 from tzlocal import get_localzone_name  # type: ignore
 
 import trino.exceptions
-from tests.unit.oauth_test_utils import (
-    REDIRECT_RESOURCE,
-    SERVER_ADDRESS,
-    TOKEN_RESOURCE,
-    GetTokenCallback,
-    MultithreadedTokenServer,
-    PostStatementCallback,
-    RedirectHandler,
-    RedirectHandlerWithException,
-    _get_token_requests,
-    _post_statement_requests,
-)
-from trino import __version__, constants
-from trino.auth import (
-    GSSAPIAuthentication,
-    KerberosAuthentication,
-    _OAuth2KeyRingTokenCache,
-    _OAuth2TokenBearer,
-)
-from trino.client import (
-    ClientSession,
-    TrinoQuery,
-    TrinoRequest,
-    TrinoResult,
-    _DelayExponential,
-    _retry_with,
-    _RetryWithExponentialBackoff,
-)
+from tests.unit.oauth_test_utils import _get_token_requests
+from tests.unit.oauth_test_utils import _post_statement_requests
+from tests.unit.oauth_test_utils import GetTokenCallback
+from tests.unit.oauth_test_utils import MultithreadedTokenServer
+from tests.unit.oauth_test_utils import PostStatementCallback
+from tests.unit.oauth_test_utils import REDIRECT_RESOURCE
+from tests.unit.oauth_test_utils import RedirectHandler
+from tests.unit.oauth_test_utils import RedirectHandlerWithException
+from tests.unit.oauth_test_utils import SERVER_ADDRESS
+from tests.unit.oauth_test_utils import TOKEN_RESOURCE
+from trino import __version__
+from trino import constants
+from trino.auth import _OAuth2KeyRingTokenCache
+from trino.auth import _OAuth2TokenBearer
+from trino.auth import GSSAPIAuthentication
+from trino.auth import KerberosAuthentication
+from trino.client import _DelayExponential
+from trino.client import _retry_with
+from trino.client import _RetryWithExponentialBackoff
+from trino.client import ClientSession
+from trino.client import TrinoQuery
+from trino.client import TrinoRequest
+from trino.client import TrinoResult
 
 
 @mock.patch("trino.client.TrinoRequest.http")

--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -17,19 +17,18 @@ import httpretty
 from httpretty import httprettified
 from requests import Session
 
-from tests.unit.oauth_test_utils import (
-    REDIRECT_RESOURCE,
-    SERVER_ADDRESS,
-    TOKEN_RESOURCE,
-    GetTokenCallback,
-    PostStatementCallback,
-    RedirectHandler,
-    _get_token_requests,
-    _post_statement_requests,
-)
+from tests.unit.oauth_test_utils import _get_token_requests
+from tests.unit.oauth_test_utils import _post_statement_requests
+from tests.unit.oauth_test_utils import GetTokenCallback
+from tests.unit.oauth_test_utils import PostStatementCallback
+from tests.unit.oauth_test_utils import REDIRECT_RESOURCE
+from tests.unit.oauth_test_utils import RedirectHandler
+from tests.unit.oauth_test_utils import SERVER_ADDRESS
+from tests.unit.oauth_test_utils import TOKEN_RESOURCE
 from trino import constants
 from trino.auth import OAuth2Authentication
-from trino.dbapi import Connection, connect
+from trino.dbapi import connect
+from trino.dbapi import Connection
 
 
 @patch("trino.dbapi.trino.client")

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -9,14 +9,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from trino import constants
-from trino.client import (
-    get_header_values,
-    get_prepared_statement_values,
-    get_roles_values,
-    get_session_property_values,
-)
+from trino.client import get_header_values
+from trino.client import get_prepared_statement_values
+from trino.client import get_roles_values
+from trino.client import get_session_property_values
 
 
 def test_get_header_values():

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pytest
 
 from trino.transaction import IsolationLevel

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -9,9 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pickle
-from datetime import datetime, time
+from datetime import datetime
+from datetime import time
 from decimal import Decimal
 
 import pytest

--- a/trino/__init__.py
+++ b/trino/__init__.py
@@ -9,17 +9,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from . import auth, client, constants, dbapi, exceptions, logging
-from ._version import (
-    __author__,
-    __author_email__,
-    __description__,
-    __license__,
-    __title__,
-    __url__,
-    __version__,
-)
+from . import auth
+from . import client
+from . import constants
+from . import dbapi
+from . import exceptions
+from . import logging
+from ._version import __author__
+from ._version import __author_email__
+from ._version import __description__
+from ._version import __license__
+from ._version import __title__
+from ._version import __url__
+from ._version import __version__
 
 __all__ = [
     "auth",

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import abc
 import importlib
 import json
@@ -17,15 +16,26 @@ import os
 import re
 import threading
 import webbrowser
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from collections.abc import Mapping
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 from urllib.parse import urlparse
 
-from requests import PreparedRequest, Request, Response, Session
-from requests.auth import AuthBase, extract_cookies_to_jar
+from requests import PreparedRequest
+from requests import Request
+from requests import Response
+from requests import Session
+from requests.auth import AuthBase
+from requests.auth import extract_cookies_to_jar
 
 import trino.logging
 from trino.client import exceptions
-from trino.constants import HEADER_USER, MAX_NT_PASSWORD_SIZE
+from trino.constants import HEADER_USER
+from trino.constants import MAX_NT_PASSWORD_SIZE
 
 logger = trino.logging.get_logger(__name__)
 

--- a/trino/client.py
+++ b/trino/client.py
@@ -46,16 +46,23 @@ from dataclasses import dataclass
 from datetime import datetime
 from email.utils import parsedate_to_datetime
 from time import sleep
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 from zoneinfo import ZoneInfo
 
 import requests
 from tzlocal import get_localzone_name  # type: ignore
 
 import trino.logging
-from trino import constants, exceptions
+from trino import constants
+from trino import exceptions
 from trino._version import __version__
-from trino.mapper import RowMapper, RowMapperFactory
+from trino.mapper import RowMapper
+from trino.mapper import RowMapperFactory
 
 __all__ = ["ClientSession", "TrinoQuery", "TrinoRequest", "PROXIES"]
 

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -9,8 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Any, Optional
+from typing import Any
+from typing import Optional
 
 DEFAULT_PORT = 8080
 DEFAULT_TLS_PORT = 443

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -25,7 +25,11 @@ from decimal import Decimal
 from itertools import islice
 from threading import Lock
 from time import time
-from typing import Any, Dict, List, NamedTuple, Optional  # NOQA for mypy types
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import Optional
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
 
@@ -33,20 +37,22 @@ import trino.client
 import trino.exceptions
 import trino.logging
 from trino import constants
-from trino.constants import LENGTH_TYPES, PRECISION_TYPES, SCALE_TYPES
-from trino.exceptions import (
-    DatabaseError,
-    DataError,
-    Error,
-    IntegrityError,
-    InterfaceError,
-    InternalError,
-    NotSupportedError,
-    OperationalError,
-    ProgrammingError,
-    Warning,
-)
-from trino.transaction import NO_TRANSACTION, IsolationLevel, Transaction
+from trino.constants import LENGTH_TYPES
+from trino.constants import PRECISION_TYPES
+from trino.constants import SCALE_TYPES
+from trino.exceptions import DatabaseError
+from trino.exceptions import DataError
+from trino.exceptions import Error
+from trino.exceptions import IntegrityError
+from trino.exceptions import InterfaceError
+from trino.exceptions import InternalError
+from trino.exceptions import NotSupportedError
+from trino.exceptions import OperationalError
+from trino.exceptions import ProgrammingError
+from trino.exceptions import Warning
+from trino.transaction import IsolationLevel
+from trino.transaction import NO_TRANSACTION
+from trino.transaction import Transaction
 
 __all__ = [
     # https://www.python.org/dev/peps/pep-0249/#globals

--- a/trino/exceptions.py
+++ b/trino/exceptions.py
@@ -14,7 +14,10 @@
 This module defines exceptions for Trino operations. It follows the structure
 defined in pep-0249.
 """
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
 
 import trino.logging
 

--- a/trino/logging.py
+++ b/trino/logging.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import logging
 from typing import Optional
 

--- a/trino/mapper.py
+++ b/trino/mapper.py
@@ -3,22 +3,31 @@ from __future__ import annotations
 import abc
 import base64
 import uuid
-from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
+from datetime import tzinfo
 from decimal import Decimal
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any
+from typing import Dict
+from typing import Generic
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import TypeVar
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 
 import trino.exceptions
-from trino.types import (
-    POWERS_OF_TEN,
-    NamedRowTuple,
-    Time,
-    Timestamp,
-    TimestampWithTimeZone,
-    TimeWithTimeZone,
-)
+from trino.types import NamedRowTuple
+from trino.types import POWERS_OF_TEN
+from trino.types import Time
+from trino.types import Timestamp
+from trino.types import TimestampWithTimeZone
+from trino.types import TimeWithTimeZone
 
 T = TypeVar("T")
 

--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -10,7 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql import compiler, sqltypes
+from sqlalchemy.sql import compiler
+from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.base import DialectKWArgs
 from sqlalchemy.sql.functions import GenericFunction
 

--- a/trino/sqlalchemy/datatype.py
+++ b/trino/sqlalchemy/datatype.py
@@ -10,12 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
+from collections.abc import Iterator
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
 
 import sqlalchemy
-from sqlalchemy import func, util
+from sqlalchemy import func
+from sqlalchemy import util
 from sqlalchemy.sql import sqltypes
-from sqlalchemy.sql.type_api import TypeDecorator, TypeEngine
+from sqlalchemy.sql.type_api import TypeDecorator
+from sqlalchemy.sql.type_api import TypeEngine
 from sqlalchemy.types import JSON
 
 SQLType = Union[TypeEngine, Type[TypeEngine]]

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -10,29 +10,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from collections.abc import Mapping
+from collections.abc import Sequence
 from textwrap import dedent
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 from urllib.parse import unquote_plus
 
-from sqlalchemy import exc, sql
+from sqlalchemy import exc
+from sqlalchemy import sql
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.base import Connection
-from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
+from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql import sqltypes
 
+from .datatype import JSONIndexType
+from .datatype import JSONPathType
 from trino import dbapi as trino_dbapi
 from trino import logging
-from trino.auth import (
-    BasicAuthentication,
-    CertificateAuthentication,
-    JWTAuthentication,
-    OAuth2Authentication,
-)
+from trino.auth import BasicAuthentication
+from trino.auth import CertificateAuthentication
+from trino.auth import JWTAuthentication
+from trino.auth import OAuth2Authentication
 from trino.dbapi import Cursor
-from trino.sqlalchemy import compiler, datatype, error
-
-from .datatype import JSONIndexType, JSONPathType
+from trino.sqlalchemy import compiler
+from trino.sqlalchemy import datatype
+from trino.sqlalchemy import error
 
 logger = logging.get_logger(__name__)
 

--- a/trino/sqlalchemy/util.py
+++ b/trino/sqlalchemy/util.py
@@ -1,6 +1,10 @@
 import json
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 from urllib.parse import quote_plus
 
 from sqlalchemy import exc

--- a/trino/transaction.py
+++ b/trino/transaction.py
@@ -9,8 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from enum import Enum, unique
-from typing import Iterable
+from collections.abc import Iterable
+from enum import Enum
+from enum import unique
 
 import trino.client
 import trino.exceptions

--- a/trino/types.py
+++ b/trino/types.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
 import abc
-from datetime import datetime, time, timedelta
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any
+from typing import cast
+from typing import Dict
+from typing import Generic
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
 
 PythonTemporalType = TypeVar("PythonTemporalType", bound=Union[time, datetime])
 POWERS_OF_TEN: Dict[int, Decimal] = {i: Decimal(10**i) for i in range(0, 13)}


### PR DESCRIPTION
## Description

See [the motivation](https://github.com/trinodb/trino-python-client/pull/500#discussion_r1880619356). Unfortunately the following reformatting is unavoidable (and cannot be reconfigured, see [the explanation](https://github.com/asottile/reorder-python-imports?tab=readme-ov-file#why-this-style)). It’s not a big deal from my POV but it’s a big change nevertheless.

```python
from trino.client import ClientSession, TrinoQuery, TrinoRequest
```
⬇️ 
```python
from trino.client import ClientSession
from trino.client import TrinoQuery
from trino.client import TrinoRequest
```

## Release notes

This is not user-visible or docs only and no release notes are required.