### PR TITLE
Add missing type annotations for the "TrinoRequest" class

### DIFF
--- a/trino/auth.py
+++ b/trino/auth.py
@@ -33,7 +33,7 @@ from requests.auth import AuthBase
 from requests.auth import extract_cookies_to_jar
 
 import trino.logging
-from trino.client import exceptions
+from trino import exceptions
 from trino.constants import HEADER_USER
 from trino.constants import MAX_NT_PASSWORD_SIZE
 


### PR DESCRIPTION
## Description

Type annotations for the `client.TrinoRequest` class based on usages and tests.

## Release notes

Release notes are required, with the following suggested text:

```markdown
* Add type annotations for `client.TrinoRequest`.
```
