### PR TITLE
fix: account for None in error field of http response

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -621,7 +621,7 @@ class TrinoRequest:
 
         http_response.encoding = "utf-8"
         response = http_response.json()
-        if "error" in response:
+        if "error" in response and response["error"]:
             raise self._process_error(response["error"], response.get("id"))
 
         if constants.HEADER_CLEAR_SESSION in http_response.headers:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When the `error` field in the REST response is `null` (`None` for the python client), assume a successful execution.

From the [docs](https://trino.io/docs/current/develop/client-protocol.html):
> If query failed, the error attribute contains a QueryError object. That object contains a message, an errorCode and other information about the error. See the io.trino.client.QueryError class in module trino-client in the client directory for more details.

> queryError | QueryError | Non-null only if the query resulted in an error.

However, sometimes (some versions of Trino) the server returns an HTTP response with the `error` field present, yet with a `None` value. Then, an exception is thrown in the client:
```bash
Traceback (most recent call last):
  File "/OBFUSCATED/main.py", line 29, in <module>
    main()
  File "/OBFUSCATED/main.py", line 25, in main
    asyncio.run(trino_scraper.start())
  File "/root/.pyenv/versions/3.11.10/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.11.10/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.11.10/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/OBFUSCATED/scrapers.py", line 165, in start
    cur.execute(
  File "/OBFUSCATED/.venv/lib/python3.11/site-packages/trino/dbapi.py", line 585, in execute
    self._iterator = iter(self._query.execute())
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/OBFUSCATED/.venv/lib/python3.11/site-packages/trino/client.py", line 814, in execute
    status = self._request.process(response)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/OBFUSCATED/.venv/lib/python3.11/site-packages/trino/client.py", line 619, in process
    raise self._process_error(response["error"], response.get("id"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/OBFUSCATED/.venv/lib/python3.11/site-packages/trino/client.py", line 584, in _process_error
    error_type = error["errorType"]
                 ~~~~~^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
Sometimes (some versions of Trino) the server returns an HTTP response with the `error` field present, yet with a `None` value.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

Fixes https://github.com/trinodb/trino-python-client/issues/511