### PR TITLE
Introduce DecodableSegment and remove Tuple in iterators

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -573,6 +573,15 @@ class TrinoRequest:
 
         return headers
 
+    def unauthenticated(self):
+        return TrinoRequest(
+            host=self._host,
+            port=self._port,
+            max_attempts=self.max_attempts,
+            request_timeout=self._request_timeout,
+            handle_retry=self._handle_retry,
+            client_session=ClientSession(user=self._client_session.user))
+
     @property
     def max_attempts(self) -> int:
         return self._max_attempts
@@ -940,7 +949,7 @@ class TrinoQuery:
                 segments.append(InlineSegment(inline_segment))
             elif segment_type == SegmentType.SPOOLED:
                 spooled_segment = cast(_SpooledSegmentTO, segment)
-                segments.append(SpooledSegment(spooled_segment, self._request))
+                segments.append(SpooledSegment(spooled_segment, self._request.unauthenticated()))
             else:
                 raise ValueError(f"Unsupported segment type: {segment_type}")
 


### PR DESCRIPTION
This makes the API much easier to consume in the `segments` cursor style:

```
cur = conn.cursor('segment')
cur.execute(sql)
segments = cur.fetchall()
total_row_count = 0
row_mapper = RowMapperFactory().create(columns=cur._query.columns, legacy_primitive_types=False)
for segment in segments:
  rows = list(SegmentIterator(segment, row_mapper))
  print ("rows length is " + str(len(rows)) + " " + segment.encoding)
  total_row_count += len(rows)
print(total_row_count)
```

This will work the same:

```
segments = cur.fetchall()
total_row_count = 0
row_mapper = RowMapperFactory().create(columns=cur._query.columns, legacy_primitive_types=False)

rows = list(SegmentIterator(segments, row_mapper))
print ("rows length is " + str(len(rows)))
total_row_count += len(rows)

print(total_row_count)
```