### PR TITLE
Allow authentication over HTTP

### DIFF
--- a/tests/unit/sqlalchemy/test_dialect.py
+++ b/tests/unit/sqlalchemy/test_dialect.py
@@ -58,7 +58,6 @@ class TestTrinoDialect:
                     catalog="system",
                     user="user",
                     auth=BasicAuthentication("user", "pass"),
-                    http_scheme="https",
                     source="trino-rulez"
                 ),
             ),
@@ -80,7 +79,6 @@ class TestTrinoDialect:
                     catalog="system",
                     user="user",
                     auth=CertificateAuthentication("/my/path/to/cert", "afdlsdfk%4#'"),
-                    http_scheme="https",
                     source="trino-sqlalchemy"
                 ),
             ),
@@ -100,7 +98,6 @@ class TestTrinoDialect:
                     catalog="system",
                     user="user",
                     auth=JWTAuthentication("afdlsdfk%4#'"),
-                    http_scheme="https",
                     source="trino-sqlalchemy"
                 ),
             ),
@@ -168,7 +165,6 @@ class TestTrinoDialect:
                     catalog="system",
                     user="user@test.org/my_role",
                     auth=BasicAuthentication("user@test.org/my_role", "pass /*&"),
-                    http_scheme="https",
                     source="trino-sqlalchemy",
                     session_properties={"query_max_run_time": "1d"},
                     http_headers={"trino": 1},
@@ -270,7 +266,6 @@ def test_trino_connection_basic_auth():
     url = make_url(f'trino://{username}:{password}@host')
     _, cparams = dialect.create_connect_args(url)
 
-    assert cparams['http_scheme'] == "https"
     assert isinstance(cparams['auth'], BasicAuthentication)
     assert cparams['auth']._username == username
     assert cparams['auth']._password == password
@@ -282,7 +277,6 @@ def test_trino_connection_jwt_auth():
     url = make_url(f'trino://host/?access_token={access_token}')
     _, cparams = dialect.create_connect_args(url)
 
-    assert cparams['http_scheme'] == "https"
     assert isinstance(cparams['auth'], JWTAuthentication)
     assert cparams['auth'].token == access_token
 
@@ -294,7 +288,6 @@ def test_trino_connection_certificate_auth():
     url = make_url(f'trino://host/?cert={cert}&key={key}')
     _, cparams = dialect.create_connect_args(url)
 
-    assert cparams['http_scheme'] == "https"
     assert isinstance(cparams['auth'], CertificateAuthentication)
     assert cparams['auth']._cert == cert
     assert cparams['auth']._key == key
@@ -307,13 +300,11 @@ def test_trino_connection_certificate_auth_cert_and_key_required():
     url = make_url(f'trino://host/?cert={cert}')
     _, cparams = dialect.create_connect_args(url)
 
-    assert 'http_scheme' not in cparams
     assert 'auth' not in cparams
 
     url = make_url(f'trino://host/?key={key}')
     _, cparams = dialect.create_connect_args(url)
 
-    assert 'http_scheme' not in cparams
     assert 'auth' not in cparams
 
 
@@ -322,5 +313,4 @@ def test_trino_connection_oauth2_auth():
     url = make_url('trino://host/?externalAuthentication=true')
     _, cparams = dialect.create_connect_args(url)
 
-    assert cparams['http_scheme'] == "https"
     assert isinstance(cparams['auth'], OAuth2Authentication)

--- a/trino/client.py
+++ b/trino/client.py
@@ -489,8 +489,6 @@ class TrinoRequest:
         self._exceptions = self.HTTP_EXCEPTIONS
         self._auth = auth
         if self._auth:
-            if self._http_scheme == constants.HTTP:
-                raise ValueError("cannot use authentication with HTTP")
             self._auth.set_http_session(self._http_session)
             self._exceptions += self._auth.get_exceptions()
 

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -133,19 +133,15 @@ class TrinoDialect(DefaultDialect):
         if url.password:
             if not url.username:
                 raise ValueError("Username is required when specify password in connection URL")
-            kwargs["http_scheme"] = "https"
             kwargs["auth"] = BasicAuthentication(unquote_plus(url.username), unquote_plus(url.password))
 
         if "access_token" in url.query:
-            kwargs["http_scheme"] = "https"
             kwargs["auth"] = JWTAuthentication(unquote_plus(url.query["access_token"]))
 
         if "cert" in url.query and "key" in url.query:
-            kwargs["http_scheme"] = "https"
             kwargs["auth"] = CertificateAuthentication(unquote_plus(url.query['cert']), unquote_plus(url.query['key']))
 
         if "externalAuthentication" in url.query:
-            kwargs["http_scheme"] = "https"
             kwargs["auth"] = OAuth2Authentication()
 
         if "source" in url.query:


### PR DESCRIPTION
## Description

The Trino Python client currently rejects all authentication attempts over HTTP. While this seems like is a sensible security measure on the part of the Trino client, using an HTTP URL to access the Trino server does not inherently indicate an insecure environment.

This could be useful for testing purposes or in modern service meshes, such as those using SPIFFE authentication where injection of the spiffe headers and adding TLS are handled by spire and envoy separately in sidecars ([doc here](https://spiffe.io/docs/latest/microservices/envoy/)). Furthermore the trino server also has the option of `http-server.authentication.allow-insecure-over-http=true` ([doc here](https://trino.io/docs/current/security/tls.html#configure-the-coordinator)) so it might be reasonable to not rejecting non-https authentication attempts in the client side.

This pull request includes the following improvements:
* The SQLAlchemy dialect no longer automatically sets `http_scheme` to `https` when authentication is detected in the connection URL.
* Authentication over HTTP is now allowed.
* To authenticate over HTTP using SQLAlchemy, the `http_scheme="http"` connection argument is now respected. If `http_scheme` is not specified, the scheme defaults to `https` when the port is 443; otherwise, it defaults to `http`.

Example auth over HTTP:
```
- DBAPI

    ```python
    from trino.dbapi import connect
    from trino.auth import BasicAuthentication

    conn = connect(
        user="<username>",
        auth=BasicAuthentication("<username>", "<password>"),
        http_scheme="http",
        ...
    )
    ```

- SQLAlchemy

    ```python
    from sqlalchemy import create_engine

    # defaults to use http if the port is not 443
    engine = create_engine("trino://<username>:<password>@<host>:<port>/<catalog>")

    # or as connect_args
    from trino.auth import BasicAuthentication
    engine = create_engine(
        "trino://<username>@<host>:<port>/<catalog>",
        connect_args={
            "auth": BasicAuthentication("<username>", "<password>"),
            "http_scheme": "http",
        }
    )
    ```
```

## Non-technical explanation

This PR adds functionality to optionally authenticate over HTTP.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Allow authentication over HTTP ({issue}`530`)
```
