### PR TITLE
Authenticate against external identity provider, and send grant to Trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,35 @@ The OAuth2 token will be cached either per `trino.auth.OAuth2Authentication` ins
     )
     ```
 
+### Keycloak Authentication
+
+The `KeycloakAuthentication` class can be used to connect to a Trino cluster that is configured with the [OAuth2 authentication type](https://trino.io/docs/current/security/oauth2.html) using an external OIDC identity provider (i.e Keycloak)
+
+It works by sending credentials to the OpenId identity provider and recieving a grant, then passing said grant to the Trino cluster secured using OAuth2
+
+> [!WARNING]
+> Client Authentication must be turned off (public access) as the flow does not send a client secret
+
+- DBAPI
+
+    ```python
+    from trino.dbapi import connect
+    from trino.auth import KeycloakAuthentication
+
+    conn = connect(
+        user="<username>",
+        auth=KeycloakAuthentication(
+            username="<username>",
+            password="<password>",
+            keycloak_url="<keycloak_url>",
+            realm="<realm>",
+            client_id="<client_id>",
+        ),
+        ...
+    )
+
+    ```
+
 ### Certificate authentication
 
 `CertificateAuthentication` class can be used to connect to Trino cluster configured with [certificate based authentication](https://trino.io/docs/current/security/certificate.html). `CertificateAuthentication` requires paths to a valid client certificate and private key.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The new `KeycloakAuthentication` auth flow allows usage of an external OIDC identity provider to authenticate against a Trino cluster secured using OAuth2.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

This authentication type uses credentials for an OpenId Connect provider, such as Keycloak, retrieves a grant token and uses it to authenticate against Trino.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

### Keycloak Authentication

The `KeycloakAuthentication` class can be used to connect to a Trino cluster that is configured with the [OAuth2 authentication type](https://trino.io/docs/current/security/oauth2.html) using an external OIDC identity provider (i.e Keycloak)

It works by sending credentials to the OpenId identity provider and recieving a grant, then passing said grant to the Trino cluster secured using OAuth2

> [!WARNING]
> Client Authentication must be turned off (public access) as the flow does not send a client secret

- DBAPI

    ```python
    from trino.dbapi import connect
    from trino.auth import KeycloakAuthentication

    conn = connect(
        user="<username>",
        auth=KeycloakAuthentication(
            username="<username>",
            password="<password>",
            keycloak_url="<keycloak_url>",
            realm="<realm>",
            client_id="<client_id>",
        ),
        ...
    )

    ```
