### PR TITLE
Ignore primary key, foreign key and unique constraints for DDL generation

### DIFF
--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -19,6 +19,7 @@ from sqlalchemy import MetaData
 from sqlalchemy import select
 from sqlalchemy import String
 from sqlalchemy import Table
+from sqlalchemy.exc import SAWarning
 from sqlalchemy.schema import CreateTable
 from sqlalchemy.sql import column
 from sqlalchemy.sql import table
@@ -194,18 +195,21 @@ def test_try_cast(dialect):
 
 
 def test_catalogs_create_table_with_pk(dialect):
-    statement = CreateTable(table_with_pk)
-    query = statement.compile(dialect=dialect)
-    assert 'primary key' not in str(query).lower()
+    with pytest.warns(SAWarning, match="Trino does not support PRIMARY KEY constraints. Constraint will be ignored."):
+        statement = CreateTable(table_with_pk)
+        query = statement.compile(dialect=dialect)
+        assert 'primary key' not in str(query).lower()
 
 
 def test_catalogs_create_table_with_fk(dialect):
-    statement = CreateTable(table_with_fk)
-    query = statement.compile(dialect=dialect)
-    assert 'foreign key' not in str(query).lower()
+    with pytest.warns(SAWarning, match="Trino does not support FOREIGN KEY constraints. Constraint will be ignored."):
+        statement = CreateTable(table_with_fk)
+        query = statement.compile(dialect=dialect)
+        assert 'foreign key' not in str(query).lower()
 
 
 def test_catalogs_create_table_with_unique(dialect):
-    statement = CreateTable(table_with_unique)
-    query = statement.compile(dialect=dialect)
-    assert 'unique' not in str(query).lower()
+    with pytest.warns(SAWarning, match="Trino does not support UNIQUE constraints. Constraint will be ignored."):
+        statement = CreateTable(table_with_unique)
+        query = statement.compile(dialect=dialect)
+        assert 'unique' not in str(query).lower()

--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 import pytest
 from sqlalchemy import Column
+from sqlalchemy import ForeignKey
 from sqlalchemy import func
 from sqlalchemy import insert
 from sqlalchemy import Integer
@@ -38,6 +39,26 @@ table_with_catalog = Table(
     Column('id', Integer),
     schema='default',
     trino_catalog='other'
+)
+
+table_with_pk = Table(
+    'table_with_pk',
+    metadata,
+    Column('id', String, primary_key=True)
+)
+
+table_with_fk = Table(
+    'table_with_fk',
+    metadata,
+    Column('id', String, primary_key=True),
+    Column('fk', String, ForeignKey('table_with_pk.id'))
+)
+
+table_with_unique = Table(
+    'table_with_constraint',
+    metadata,
+    Column('id', String, primary_key=True),
+    Column('uniq', String, unique=True)
 )
 
 
@@ -170,3 +191,21 @@ def test_try_cast(dialect):
     statement = select(try_cast(table_without_catalog.c.id, String))
     query = statement.compile(dialect=dialect)
     assert str(query) == 'SELECT try_cast("table".id as VARCHAR) AS id \nFROM "table"'
+
+
+def test_catalogs_create_table_with_pk(dialect):
+    statement = CreateTable(table_with_pk)
+    query = statement.compile(dialect=dialect)
+    assert 'primary key' not in str(query).lower()
+
+
+def test_catalogs_create_table_with_fk(dialect):
+    statement = CreateTable(table_with_fk)
+    query = statement.compile(dialect=dialect)
+    assert 'foreign key' not in str(query).lower()
+
+
+def test_catalogs_create_table_with_unique(dialect):
+    statement = CreateTable(table_with_unique)
+    query = statement.compile(dialect=dialect)
+    assert 'unique' not in str(query).lower()

--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -14,6 +14,7 @@ from sqlalchemy.sql import compiler
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.base import DialectKWArgs
 from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.util import warn as SAWarn
 
 # https://trino.io/docs/current/language/reserved.html
 RESERVED_WORDS = {
@@ -182,12 +183,15 @@ class TrinoSQLCompiler(compiler.SQLCompiler):
 
 class TrinoDDLCompiler(compiler.DDLCompiler):
     def visit_foreign_key_constraint(self, constraint, **kw):
+        SAWarn("Trino does not support FOREIGN KEY constraints. Constraint will be ignored.")
         return None
 
     def visit_primary_key_constraint(self, constraint, **kw):
+        SAWarn("Trino does not support PRIMARY KEY constraints. Constraint will be ignored.")
         return None
 
     def visit_unique_constraint(self, constraint, **kw):
+        SAWarn("Trino does not support UNIQUE constraints. Constraint will be ignored.")
         return None
 
 

--- a/trino/sqlalchemy/compiler.py
+++ b/trino/sqlalchemy/compiler.py
@@ -181,7 +181,14 @@ class TrinoSQLCompiler(compiler.SQLCompiler):
 
 
 class TrinoDDLCompiler(compiler.DDLCompiler):
-    pass
+    def visit_foreign_key_constraint(self, constraint, **kw):
+        return None
+
+    def visit_primary_key_constraint(self, constraint, **kw):
+        return None
+
+    def visit_unique_constraint(self, constraint, **kw):
+        return None
 
 
 class TrinoTypeCompiler(compiler.GenericTypeCompiler):


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Define custom visitors in `TrinoDDLCompiler` to ignore constraints.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

By default, SQLAlchemy adds `PRIMARY KEY` and other constraint keywords to table creation DDL when these constraints are defined on a `Table` or class derived from declarative base. Since Trino does not support constraints, this results in invalid SQL. With this change the trino sqlalchemy extension now ignores primary key, foreign key and unique constraints when generating table DDL.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* ignore constraints for table DDL generation
```
