### PR TITLE
Fix typing of kerberos mutual_authentication

### DIFF
--- a/trino/auth.py
+++ b/trino/auth.py
@@ -50,11 +50,15 @@ class Authentication(metaclass=abc.ABCMeta):
 
 
 class KerberosAuthentication(Authentication):
+    MUTUAL_REQUIRED = 1
+    MUTUAL_OPTIONAL = 2
+    MUTUAL_DISABLED = 3
+
     def __init__(
         self,
         config: Optional[str] = None,
         service_name: Optional[str] = None,
-        mutual_authentication: bool = False,
+        mutual_authentication: int = MUTUAL_REQUIRED,
         force_preemptive: bool = False,
         hostname_override: Optional[str] = None,
         sanitize_mutual_error_response: bool = True,
@@ -117,11 +121,15 @@ class KerberosAuthentication(Authentication):
 
 
 class GSSAPIAuthentication(Authentication):
+    MUTUAL_REQUIRED = 1
+    MUTUAL_OPTIONAL = 2
+    MUTUAL_DISABLED = 3
+
     def __init__(
         self,
         config: Optional[str] = None,
         service_name: Optional[str] = None,
-        mutual_authentication: bool = False,
+        mutual_authentication: int = MUTUAL_DISABLED,
         force_preemptive: bool = False,
         hostname_override: Optional[str] = None,
         sanitize_mutual_error_response: bool = True,


### PR DESCRIPTION
## Description

Fix #513 by correcting `mutual_authentication` type annotation and adding corresponding mutual authentication modes constants.

* Introduce constants for Kerberos and GSSAPI mutual authentication modes within `KerberosAuthentication` and `GSSAPIAuthentication` classes.
* Set proper type annotations and default values for `mutual_authentication` attributes.
  * Default values are replicated from corresponding defaults in `requests_kerberos`/`requests_gssapi`.

## Non-technical explanation

Kerberos/GSSAPI libraries (`requests_kerberos` and `requests_gssapi`) expect `mutual_authentication` parameter to be an integer:
* `1` for "required"
* `2` for "optional"
* `3` for "disabled"

However, the same parameter in `trino-python-client` is annotated as `bool`. By luck, due to the order of conditions and the fact that `True == 1`, Kerberos/GSSAPI libraries handle `True`/`False` as "required"/"disabled" modes.

This is non-breaking change, but it can streamline the usage of `KerberosAuthentication` a bit:

```python
### before
from requests_kerberos import OPTIONAL
from trino.auth import KerberosAuthentication

auth = KerberosAuthentication(
    principal="username",
    mutual_authentication=OPTIONAL,  # type: ignore
    service_name="HTTP",
)

### after
from trino.auth import KerberosAuthentication

auth = KerberosAuthentication(
    principal="username",
    mutual_authentication=KerberosAuthentication.OPTIONAL,
    service_name="HTTP",
)
```

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix type annotation for `mutual_authentication` parameter in Kerberos/GSSAPI authentication ({issue}`513`).
```
