### PR TITLE
Pass HTTP SSL verify flag

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -578,7 +578,8 @@ class TrinoRequest:
             max_attempts=self.max_attempts,
             request_timeout=self._request_timeout,
             handle_retry=self._handle_retry,
-            client_session=ClientSession(user=self._client_session.user))
+            client_session=ClientSession(user=self._client_session.user),
+            verify=self._http_session.verify)
 
     @property
     def max_attempts(self) -> int:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When setting SSL Verify flag to false, use that in HTTP requests, for example, HTTP requests for spooled segments

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

HTTP SSL Verification flag not passed to SpooledSegment class which fails HTTP requests

SSL Verification flag set to False when initialising a connection to Trino is not passed to HTTP requests for spooled segments and therefore fails with HTTP SSL errors

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix issue: [543](https://github.com/trinodb/trino-python-client/issues/543)
```
