### PR TITLE
Fix print oauth url without flush

### DIFF
--- a/trino/auth.py
+++ b/trino/auth.py
@@ -291,8 +291,7 @@ class ConsoleRedirectHandler(RedirectHandler):
     """
 
     def __call__(self, url: str) -> None:
-        print("Open the following URL in browser for the external authentication:")
-        print(url)
+        print(f"Open the following URL in browser for the external authentication:\n{url}", flush=True)
 
 
 class WebBrowserRedirectHandler(RedirectHandler):


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

PR for https://github.com/trinodb/trino-python-client/issues/544

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make it possible to passing oauth link through Power User for DBT plugin.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix print oauth url without flush. ({issue}`544`)
```
