### PR TITLE
add SESSION_AUTHORIZATION to client capabilities

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -135,7 +135,7 @@ def test_request_headers(mock_get_and_post):
         assert headers[constants.HEADER_SESSION] == ""
         assert headers[constants.HEADER_TRANSACTION] is None
         assert headers[constants.HEADER_TIMEZONE] == timezone
-        assert headers[constants.HEADER_CLIENT_CAPABILITIES] == "PARAMETRIC_DATETIME"
+        assert headers[constants.HEADER_CLIENT_CAPABILITIES] == "PARAMETRIC_DATETIME,SESSION_AUTHORIZATION"
         assert headers[accept_encoding_header] == accept_encoding_value
         assert headers[client_info_header] == client_info_value
         assert headers[constants.HEADER_ROLE] == (
@@ -1173,7 +1173,7 @@ def test_trino_query_response_headers(sample_get_response_data):
     sql = 'execute my_stament using 1, 2, 3'
     additional_headers = {
         constants.HEADER_PREPARED_STATEMENT: 'my_statement=added_prepare_statement_header',
-        constants.HEADER_CLIENT_CAPABILITIES: 'PARAMETRIC_DATETIME'
+        constants.HEADER_CLIENT_CAPABILITIES: 'PARAMETRIC_DATETIME,SESSION_AUTHORIZATION'
     }
 
     # Patch the post function to avoid making the requests, as well as to

--- a/trino/client.py
+++ b/trino/client.py
@@ -522,7 +522,7 @@ class TrinoRequest:
             headers[constants.HEADER_ENCODING] = self._client_session.encoding
         else:
             raise ValueError("Invalid type for encoding: expected str or list")
-        headers[constants.HEADER_CLIENT_CAPABILITIES] = 'PARAMETRIC_DATETIME'
+        headers[constants.HEADER_CLIENT_CAPABILITIES] = 'PARAMETRIC_DATETIME,SESSION_AUTHORIZATION'
         headers["user-agent"] = f"{constants.CLIENT_NAME}/{__version__}"
         if len(self._client_session.roles.values()):
             headers[constants.HEADER_ROLE] = ",".join(


### PR DESCRIPTION
## Description
PR seeks to resolve issue https://github.com/trinodb/trino-python-client/issues/545.

[Trino expects the Client Capabilities header](https://github.com/trinodb/trino/blob/71390927f48d0aaf1372476e761fdf4a427ccb96/core/trino-main/src/main/java/io/trino/execution/SetSessionAuthorizationTask.java#L67-L69) `SESSION_AUTHORIZATION` exists so that it allows the `SET SESSION AUTHORIZATION`.

[This wasn't added in the initial PR](https://github.com/trinodb/trino-python-client/pull/349)

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix `SET SESSION AUTHORIZATION` not working. ({issue}`545`)
```
