### PR TITLE
Provide an option to use orjson instead of json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
           cache: "pip"
           cache-dependency-path: setup.py
       - name: Install dependencies
+        if: matrix.python != 'pypy-3.9' && matrix.python != 'pypy-3.10'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libkrb5-dev
+          pip install wheel
+          pip install .[tests,gssapi,orjson] sqlalchemy${{ matrix.sqlalchemy }}
+      - name: Install dependencies in pypy
+        if: matrix.python == 'pypy-3.9' || matrix.python == 'pypy-3.10'
         run: |
           sudo apt-get update
           sudo apt-get install libkrb5-dev

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,13 @@ gssapi_require = [""
                   # PyPy compatibility issue https://github.com/jborean93/pykrb5/issues/49
                   "krb5 == 0.5.1"]
 sqlalchemy_require = ["sqlalchemy >= 1.3"]
+orjson_require = ["orjson >= 3.0.0"]
 external_authentication_token_cache_require = ["keyring"]
 
 # We don't add localstorage_require to all_require as users must explicitly opt in to use keyring.
 all_require = kerberos_require + sqlalchemy_require
 
-tests_require = all_require + gssapi_require + [
+tests_require = all_require + gssapi_require + orjson_require + [
     # httpretty >= 1.1 duplicates requests in `httpretty.latest_requests`
     # https://github.com/gabrielfalcao/HTTPretty/issues/425
     "httpretty < 1.1",
@@ -96,6 +97,7 @@ setup(
         "kerberos": kerberos_require,
         "gssapi": gssapi_require,
         "sqlalchemy": sqlalchemy_require,
+        "orjson": orjson_require,
         "tests": tests_require,
         "external-authentication-token-cache": external_authentication_token_cache_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ external_authentication_token_cache_require = ["keyring"]
 # We don't add localstorage_require to all_require as users must explicitly opt in to use keyring.
 all_require = kerberos_require + sqlalchemy_require
 
-tests_require = all_require + gssapi_require + orjson_require + [
+tests_require = all_require + gssapi_require + [
     # httpretty >= 1.1 duplicates requests in `httpretty.latest_requests`
     # https://github.com/gabrielfalcao/HTTPretty/issues/425
     "httpretty < 1.1",

--- a/trino/client.py
+++ b/trino/client.py
@@ -39,7 +39,10 @@ import atexit
 import base64
 import copy
 import functools
-import json
+try:
+    import orjson as json
+except ImportError:
+    import json
 import os
 import random
 import re

--- a/trino/client.py
+++ b/trino/client.py
@@ -39,13 +39,10 @@ import atexit
 import base64
 import copy
 import functools
-try:
-    import orjson as json
-except ImportError:
-    import json
 import os
 import random
 import re
+import sys
 import threading
 import urllib.parse
 import warnings
@@ -86,6 +83,14 @@ from trino.exceptions import TrinoQueryError
 from trino.exceptions import TrinoUserError
 from trino.mapper import RowMapper
 from trino.mapper import RowMapperFactory
+
+try:
+    if sys.implementation.name == 'pypy':
+        import json
+    else:
+        import orjson as json
+except ImportError:
+    import json
 
 __all__ = [
     "ClientSession",

--- a/trino/client.py
+++ b/trino/client.py
@@ -42,7 +42,6 @@ import functools
 import os
 import random
 import re
-import sys
 import threading
 import urllib.parse
 import warnings
@@ -85,10 +84,7 @@ from trino.mapper import RowMapper
 from trino.mapper import RowMapperFactory
 
 try:
-    if sys.implementation.name == 'pypy':
-        import json
-    else:
-        import orjson as json
+    import orjson as json
 except ImportError:
     import json
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
orjson is a fast JSON library in Python.
https://github.com/ijl/orjson?tab=readme-ov-file#performance

In my usage, `json.loads()` is one of the bottlenecks in performance when fetching a large result from a query.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
- Provide an option to use orjson instead of json for faster query result fetching.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
