### PR TITLE
Fix logic for setting http_scheme

### DIFF
--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -150,7 +150,7 @@ class Connection:
         schema=constants.DEFAULT_SCHEMA,
         session_properties=None,
         http_headers=None,
-        http_scheme=constants.HTTP,
+        http_scheme=None,
         auth=constants.DEFAULT_AUTH,
         extra_credential=None,
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
@@ -202,7 +202,18 @@ class Connection:
         else:
             self._http_session = http_session
         self.http_headers = http_headers
-        self.http_scheme = http_scheme if not parsed_host.scheme else parsed_host.scheme
+
+        # Set http_scheme
+        if parsed_host.scheme:
+            self.http_scheme = parsed_host.scheme
+        elif http_scheme:
+            self.http_scheme = http_scheme
+        elif port == constants.DEFAULT_TLS_PORT:
+            self.http_scheme = constants.HTTPS
+        elif port == constants.DEFAULT_PORT:
+            self.http_scheme = constants.HTTP
+        else:
+            self.http_scheme = constants.HTTP
 
         # Infer connection port: `hostname` takes precedence over explicit `port` argument
         # If none is given, use default based on HTTP protocol


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Resolves #556 #557 
Include inferring http_scheme from port, in logic which sets http_scheme.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
