### PR TITLE
import get_localzone_name only if timezone not avaiable

### DIFF
--- a/trino/client.py
+++ b/trino/client.py
@@ -71,7 +71,6 @@ import zstandard
 from requests import Response
 from requests import Session
 from requests.structures import CaseInsensitiveDict
-from tzlocal import get_localzone_name  # type: ignore
 
 import trino.logging
 from trino import constants
@@ -184,9 +183,12 @@ class ClientSession:
         self._extra_credential = extra_credential
         self._client_tags = client_tags.copy() if client_tags is not None else list()
         self._roles = self._format_roles(roles) if roles is not None else {}
-        self._timezone = timezone or get_localzone_name()
         if timezone:  # Check timezone validity
             ZoneInfo(timezone)
+            self._timezone = timezone
+        else:
+            from tzlocal import get_localzone_name
+            self._timezone = get_localzone_name()
         self._encoding = encoding
 
     @property


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`get_localzone_name` was added in `tzlocal 4.0` and not available in older version.
Move the import to provide a workaround using older version of tzlocal


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
