### PR TITLE
Migrate from built-in json to faster orjson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "lz4",
+        "orjson >= 3.11.0 ; platform_python_implementation != 'PyPy'",
         "python-dateutil",
         "pytz",
         # requests CVE https://github.com/advisories/GHSA-j8r2-6x86-q33q

--- a/trino/client.py
+++ b/trino/client.py
@@ -39,7 +39,6 @@ import atexit
 import base64
 import copy
 import functools
-import json
 import os
 import random
 import re
@@ -66,6 +65,11 @@ from typing import Union
 from zoneinfo import ZoneInfo
 
 import lz4.block
+try:
+    import orjson as json
+except ImportError:
+    import json
+
 import requests
 import zstandard
 from requests import Response
@@ -687,7 +691,7 @@ class TrinoRequest:
             self.raise_response_error(http_response)
 
         http_response.encoding = "utf-8"
-        response = http_response.json()
+        response = json.loads(http_response.text)
         if "error" in response and response["error"]:
             raise self._process_error(response["error"], response.get("id"))
 


### PR DESCRIPTION
It is way faster than the current json parser: https://github.com/ijl/orjson?tab=readme-ov-file#performance

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
