### PR TITLE
Handle secondary TLS port 8443 as https by default

### DIFF
--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -325,6 +325,7 @@ def test_description_is_none_when_cursor_is_not_executed():
         ("http://mytrinoserver.domain:9999", None, None, constants.HTTP),
         # Infer from port
         ("mytrinoserver.domain", constants.DEFAULT_TLS_PORT, None, constants.HTTPS),
+        ("mytrinoserver.domain", constants.SECONDARY_TLS_PORT, None, constants.HTTPS),
         ("mytrinoserver.domain", constants.DEFAULT_PORT, None, constants.HTTP),
         # http_scheme parameter has higher precedence than port parameter
         ("mytrinoserver.domain", constants.DEFAULT_TLS_PORT, constants.HTTP, constants.HTTP),

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 DEFAULT_PORT = 8080
 DEFAULT_TLS_PORT = 443
+SECONDARY_TLS_PORT = 8443
 DEFAULT_SOURCE = "trino-python-client"
 DEFAULT_CATALOG: Optional[str] = None
 DEFAULT_SCHEMA: Optional[str] = None

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -208,7 +208,7 @@ class Connection:
             self.http_scheme = parsed_host.scheme
         elif http_scheme:
             self.http_scheme = http_scheme
-        elif port == constants.DEFAULT_TLS_PORT:
+        elif port in (constants.DEFAULT_TLS_PORT, constants.SECONDARY_TLS_PORT):
             self.http_scheme = constants.HTTPS
         elif port == constants.DEFAULT_PORT:
             self.http_scheme = constants.HTTP


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Before 0.334.0, both `login@password:host:443` and `login@password:host:8443` URLs were handled as HTTPS because the connection string contained a password, and `https` was enforced by Trino in such situations.

https://github.com/trinodb/trino-python-client/pull/530 removed this enforcement. And all connection strings without an explicitly specified additional schema parameter were treated as `http`.

https://github.com/trinodb/trino-python-client/pull/564 added a fix for the 443 port. And 443 port only.
 
Meanwhile, 8443 is a secondary HTTPS/TLS port, just as 8080 is a secondary port for port 80. Even trino TLS documentation uses 8443 by default: https://trino.io/docs/current/security/tls.html

This PR adds handling of 8443 port as HTTPS by default.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Connection strings with 8443 port should be handled as HTTPS by default.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x ) Release notes are required, with the following suggested text: 

```markdown
* 8443 port is handled as HTTPS by default (#580)
```
