### PR TITLE
Retry on HTTP 200 with empty response body

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1094,6 +1094,32 @@ def test_429_error_retry(monkeypatch):
     assert post_retry.retry_count == 3
 
 
+def test_empty_200_response_retry(monkeypatch):
+    http_resp = TrinoRequest.http.Response()
+    http_resp.status_code = 200
+    http_resp._content = b""
+
+    post_retry = RetryRecorder(result=http_resp)
+    monkeypatch.setattr(TrinoRequest.http.Session, "post", post_retry)
+
+    get_retry = RetryRecorder(result=http_resp)
+    monkeypatch.setattr(TrinoRequest.http.Session, "get", get_retry)
+
+    attempts = 3
+    req = TrinoRequest(
+        host="coordinator",
+        port=8080,
+        client_session=ClientSession(user="test"),
+        max_attempts=attempts,
+    )
+
+    req.post("SELECT 1")
+    assert post_retry.retry_count == attempts
+
+    req.get("URL")
+    assert get_retry.retry_count == attempts
+
+
 @pytest.mark.parametrize("status_code", [
     501
 ])

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -813,6 +813,28 @@ def test_trino_connection_error(monkeypatch, error_code, error_type, error_messa
     assert error_message in str(error)
 
 
+def test_trino_process_empty_200_response_error():
+    req = TrinoRequest(
+        host="coordinator",
+        port=8080,
+        client_session=ClientSession(
+            user="test",
+            source="test",
+            catalog="test",
+            schema="test",
+            properties={},
+        ),
+        http_scheme="http",
+    )
+
+    http_resp = TrinoRequest.http.Response()
+    http_resp.status_code = 200
+    http_resp._content = b""
+    with pytest.raises(trino.exceptions.TrinoConnectionError) as error:
+        req.process(http_resp)
+    assert "received empty response from server (status 200)" in str(error.value)
+
+
 def test_extra_credential(mock_get_and_post):
     _, post = mock_get_and_post
 

--- a/trino/client.py
+++ b/trino/client.py
@@ -641,6 +641,9 @@ class TrinoRequest:
                 # need retry when there is no exception but the status code is 429, 502, 503, or 504
                 lambda response: getattr(response, "status_code", None)
                 in (429, 502, 503, 504),
+                # need retry when the server returns 200 with an empty body (transient under load)
+                lambda response: getattr(response, "status_code", None) == 200
+                and not getattr(response, "text", "").strip(),
             ),
             max_attempts=self._max_attempts,
         )
@@ -723,6 +726,10 @@ class TrinoRequest:
             self.raise_response_error(http_response)
 
         http_response.encoding = "utf-8"
+        if not http_response.text.strip():
+            raise exceptions.TrinoConnectionError(
+                "received empty response from server (status 200)"
+            )
         response = json.loads(http_response.text)
         if "error" in response and response["error"]:
             raise self._process_error(response["error"], response.get("id"))


### PR DESCRIPTION
## Description

fixed #596 

`TrinoRequest.process()` calls `json.loads(http_response.text)`
immediately after checking `http_response.ok`. When Trino returns
HTTP 200 with an empty body under load, this raises a bare
`JSONDecodeError` that is not in the `handled_exceptions` list of
`_retry_with`, so no retry is attempted and the exception
propagates unhandled to the caller.

Two changes to address this:

- Add a retry condition in `max_attempts.setter` for HTTP 200
  responses with an empty body, so the existing exponential
  backoff mechanism retries them — consistent with how 429/502/
  503/504 are already handled.
- Add a guard in `process()` that raises `TrinoConnectionError`
  with a descriptive message if an empty body reaches that point
  (e.g. after retries are exhausted), instead of leaking a raw
  `JSONDecodeError`.

## Non-technical explanation

When the server returned an empty response under load, the client
crashed with an unhelpful `JSONDecodeError`. It now retries
automatically and, if retries are exhausted, raises a clear error
message.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix client crash with `JSONDecodeError` on HTTP 200 with empty
  response body by retrying the request. ({issue}`596`)
```