### PR TITLE
Replace EOL PyPy 3.9/3.10 with PyPy 3.11 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
           "3.11",
           "3.12",
           "3.13",
-          "pypy-3.9",
-          "pypy-3.10",
+          "pypy-3.11",
         ]
         trino: [
           "latest",
@@ -76,7 +75,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install libkrb5-dev
           pip install wheel
-          pip install .[tests,gssapi] sqlalchemy${{ matrix.sqlalchemy }}
+          # gssapi is CPython-only; skip it on PyPy
+          if [[ "${{ matrix.python }}" == pypy-* ]]; then
+            pip install .[tests] sqlalchemy${{ matrix.sqlalchemy }}
+          else
+            pip install .[tests,gssapi] sqlalchemy${{ matrix.sqlalchemy }}
+          fi
       - name: Run tests
         run: |
           pytest -s tests/

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ external_authentication_token_cache_require = ["keyring"]
 # We don't add localstorage_require to all_require as users must explicitly opt in to use keyring.
 all_require = kerberos_require + sqlalchemy_require
 
-tests_require = all_require + gssapi_require + [
+tests_require = all_require + [
     # httpretty >= 1.1 duplicates requests in `httpretty.latest_requests`
     # https://github.com/gabrielfalcao/HTTPretty/issues/425
     "httpretty < 1.1",

--- a/tests/unit/test_auth_gssapi.py
+++ b/tests/unit/test_auth_gssapi.py
@@ -1,0 +1,87 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from contextlib import nullcontext as does_not_raise
+from typing import Any
+
+import pytest
+import requests
+
+gssapi = pytest.importorskip("gssapi", exc_type=ImportError)
+
+from trino.auth import GSSAPIAuthentication  # noqa: E402
+
+
+class MockGssapiCredentials:
+    def __init__(self, name: gssapi.Name, usage: str):
+        self.name = name
+        self.usage = usage
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, MockGssapiCredentials):
+            return False
+        return (
+            self.name == other.name,
+            self.usage == other.usage,
+        )
+
+
+@pytest.fixture
+def mock_gssapi_creds(monkeypatch):
+    monkeypatch.setattr("gssapi.Credentials", MockGssapiCredentials)
+
+
+def _gssapi_uname(spn: str):
+    return gssapi.Name(spn, gssapi.NameType.user)
+
+
+def _gssapi_sname(principal: str):
+    return gssapi.Name(principal, gssapi.NameType.hostbased_service)
+
+
+@pytest.mark.parametrize(
+    "options, expected_credentials, expected_hostname, expected_exception",
+    [
+        (
+            {}, None, None, does_not_raise(),
+        ),
+        (
+            {"hostname_override": "foo"}, None, "foo", does_not_raise(),
+        ),
+        (
+            {"service_name": "bar"}, None, None,
+            pytest.raises(ValueError, match=r"must be used together with hostname_override"),
+        ),
+        (
+            {"hostname_override": "foo", "service_name": "bar"}, None, _gssapi_sname("bar@foo"), does_not_raise(),
+        ),
+        (
+            {"principal": "foo"}, MockGssapiCredentials(_gssapi_uname("foo"), "initial"), None, does_not_raise(),
+        ),
+    ]
+)
+def test_authentication_gssapi_init_arguments(
+    options,
+    expected_credentials,
+    expected_hostname,
+    expected_exception,
+    mock_gssapi_creds,
+    monkeypatch,
+):
+    auth = GSSAPIAuthentication(**options)
+
+    session = requests.Session()
+
+    with expected_exception:
+        auth.set_http_session(session)
+
+        assert session.auth.target_name == expected_hostname
+        assert session.auth.creds == expected_credentials

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,8 +13,6 @@ import threading
 import time
 import urllib
 import uuid
-from contextlib import nullcontext as does_not_raise
-from typing import Any
 from typing import Dict
 from typing import Optional
 from unittest import mock
@@ -22,7 +20,6 @@ from unittest import TestCase
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfoNotFoundError
 
-import gssapi
 import httpretty
 import keyring
 try:
@@ -32,8 +29,6 @@ except ImportError:
 import pytest
 import requests
 from httpretty import httprettified
-from requests_gssapi.exceptions import SPNEGOExchangeError
-from requests_kerberos.exceptions import KerberosExchangeError
 from tzlocal import get_localzone_name  # type: ignore
 
 import trino.exceptions
@@ -51,8 +46,6 @@ from trino import __version__
 from trino import constants
 from trino.auth import _OAuth2KeyRingTokenCache
 from trino.auth import _OAuth2TokenBearer
-from trino.auth import GSSAPIAuthentication
-from trino.auth import KerberosAuthentication
 from trino.client import _DelayExponential
 from trino.client import _retry_with
 from trino.client import _RetryWithExponentialBackoff
@@ -61,6 +54,29 @@ from trino.client import CompressedQueryDataDecoderFactory
 from trino.client import TrinoQuery
 from trino.client import TrinoRequest
 from trino.client import TrinoResult
+
+try:
+    from requests_kerberos.exceptions import KerberosExchangeError
+    from trino.auth import KerberosAuthentication
+except ImportError:
+    KerberosAuthentication = None
+    KerberosExchangeError = None
+
+try:
+    from requests_gssapi.exceptions import SPNEGOExchangeError
+    from trino.auth import GSSAPIAuthentication
+except ImportError:
+    GSSAPIAuthentication = None
+    SPNEGOExchangeError = None
+
+requires_kerberos = pytest.mark.skipif(
+    KerberosAuthentication is None,
+    reason="requests_kerberos is not installed",
+)
+requires_gssapi = pytest.mark.skipif(
+    GSSAPIAuthentication is None,
+    reason="gssapi is not available (CPython-only)",
+)
 
 
 @mock.patch("trino.client.TrinoRequest.http")
@@ -914,73 +930,6 @@ def test_extra_credential_value_object(mock_get_and_post):
     assert headers[constants.HEADER_EXTRA_CREDENTIAL] == "foo=changed"
 
 
-class MockGssapiCredentials:
-    def __init__(self, name: gssapi.Name, usage: str):
-        self.name = name
-        self.usage = usage
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, MockGssapiCredentials):
-            return False
-        return (
-            self.name == other.name,
-            self.usage == other.usage,
-        )
-
-
-@pytest.fixture
-def mock_gssapi_creds(monkeypatch):
-    monkeypatch.setattr("gssapi.Credentials", MockGssapiCredentials)
-
-
-def _gssapi_uname(spn: str):
-    return gssapi.Name(spn, gssapi.NameType.user)
-
-
-def _gssapi_sname(principal: str):
-    return gssapi.Name(principal, gssapi.NameType.hostbased_service)
-
-
-@pytest.mark.parametrize(
-    "options, expected_credentials, expected_hostname, expected_exception",
-    [
-        (
-            {}, None, None, does_not_raise(),
-        ),
-        (
-            {"hostname_override": "foo"}, None, "foo", does_not_raise(),
-        ),
-        (
-            {"service_name": "bar"}, None, None,
-            pytest.raises(ValueError, match=r"must be used together with hostname_override"),
-        ),
-        (
-            {"hostname_override": "foo", "service_name": "bar"}, None, _gssapi_sname("bar@foo"), does_not_raise(),
-        ),
-        (
-            {"principal": "foo"}, MockGssapiCredentials(_gssapi_uname("foo"), "initial"), None, does_not_raise(),
-        ),
-    ]
-)
-def test_authentication_gssapi_init_arguments(
-    options,
-    expected_credentials,
-    expected_hostname,
-    expected_exception,
-    mock_gssapi_creds,
-    monkeypatch,
-):
-    auth = GSSAPIAuthentication(**options)
-
-    session = requests.Session()
-
-    with expected_exception:
-        auth.set_http_session(session)
-
-        assert session.auth.target_name == expected_hostname
-        assert session.auth.creds == expected_credentials
-
-
 class RetryRecorder:
     def __init__(self, error=None, result=None):
         self.__name__ = "RetryRecorder"
@@ -1003,8 +952,8 @@ class RetryRecorder:
 @pytest.mark.parametrize(
     "auth_class, retry_exception_class",
     [
-        (KerberosAuthentication, KerberosExchangeError),
-        (GSSAPIAuthentication, SPNEGOExchangeError),
+        pytest.param(KerberosAuthentication, KerberosExchangeError, marks=requires_kerberos),
+        pytest.param(GSSAPIAuthentication, SPNEGOExchangeError, marks=requires_gssapi),
     ]
 )
 def test_authentication_fail_retry(auth_class, retry_exception_class, monkeypatch):


### PR DESCRIPTION
## Summary

- Replace EOL `pypy-3.9`/`pypy-3.10` with `pypy-3.11` in CI matrix
- Skip `gssapi` extra on PyPy — the C extension is CPython-only
- Remove `gssapi_require` from `tests_require` so extras are composable
- Extract gssapi-specific tests to `test_auth_gssapi.py` with `pytest.importorskip`

Fixes #606

## Problem

Two issues broke PyPy CI:

1. `cryptography` >= 47.0.0 dropped pre-built wheels for PyPy < 3.11. Without a wheel, pip builds from source and fails because PyO3 0.28.3 requires PyPy >= 3.11. Dependency chain: `keyring` → `SecretStorage` → `cryptography`.

2. `gssapi` is CPython-only. On PyPy 3.9 a cached pre-built wheel happened to work. On PyPy 3.11 it builds from source and produces a `.so` referencing `_PyGC_FINALIZED` — a CPython internal not present in PyPy:

```
ImportError: gssapi/raw/creds.pypy311-pp73-x86_64-linux-gnu.so: undefined symbol: _PyGC_FINALIZED
```

## Root cause

The CI install step and `setup.py` both assumed gssapi is universally installable. `tests_require` bundled `gssapi_require`, so even `pip install .[tests]` pulled CPython-only C extensions on PyPy.

## Fix

| Layer | Change |
|---|---|
| `setup.py` | Remove `gssapi_require` from `tests_require` — `.[tests]` should not pull CPython-only deps |
| `ci.yml` | Install `.[tests,gssapi]` on CPython, `.[tests]` on PyPy |
| `test_client.py` | Guard kerberos/gssapi imports with try/except; use `pytest.param(..., marks=requires_gssapi)` for the shared `test_authentication_fail_retry` |
| `test_auth_gssapi.py` (new) | Pure gssapi tests with `pytest.importorskip("gssapi")` — entire module skips cleanly on PyPy |

On CPython with `.[tests,gssapi]`, all tests run as before. On PyPy with `.[tests]`, gssapi tests skip with a clear reason.

## Test plan

- [ ] CI `build (pypy-3.11, latest, ~=1.4.0)` passes with gssapi tests skipped
- [ ] All CPython matrix jobs pass with full gssapi test coverage
- [x] Verified locally: `test_client.py` — 46 passed, 2 skipped; `test_auth_gssapi.py` — 1 skipped (module-level importorskip)

- [x] Yes, this is an AI-assisted PR.