### PR TITLE
fix(sqlalchemy): add literal_processor to TIMESTAMP type

### DIFF
--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -9,6 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
+
 import pytest
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -25,6 +27,7 @@ from sqlalchemy.sql import column
 from sqlalchemy.sql import table
 
 from tests.unit.conftest import sqlalchemy_version
+from trino.sqlalchemy.datatype import TIMESTAMP
 from trino.sqlalchemy.dialect import TrinoDialect
 
 metadata = MetaData()
@@ -204,6 +207,24 @@ def test_try_cast(dialect):
     statement = select(try_cast(table_without_catalog.c.id, String))
     query = statement.compile(dialect=dialect)
     assert str(query) == 'SELECT try_cast("table".id as VARCHAR) AS id \nFROM "table"'
+
+
+def test_timestamp_literal_processor(dialect):
+    ts_col = column("ts", TIMESTAMP())
+    tbl = table("t", ts_col)
+    dt = datetime.datetime(2026, 6, 17, 9, 57, 43, 244000)
+    stmt = select(tbl).where(ts_col == dt)
+    query = stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    assert "TIMESTAMP '2026-06-17 09:57:43.244'" in str(query)
+
+
+def test_timestamp_literal_processor_no_microseconds(dialect):
+    ts_col = column("ts", TIMESTAMP())
+    tbl = table("t", ts_col)
+    dt = datetime.datetime(2026, 6, 17, 9, 57, 43)
+    stmt = select(tbl).where(ts_col == dt)
+    query = stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    assert "TIMESTAMP '2026-06-17 09:57:43'" in str(query)
 
 
 def test_catalogs_create_table_with_pk(dialect):

--- a/trino/sqlalchemy/datatype.py
+++ b/trino/sqlalchemy/datatype.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import re
 from collections.abc import Iterator
 from typing import Any
@@ -80,6 +81,17 @@ class TIMESTAMP(sqltypes.TIMESTAMP):
     def __init__(self, precision=None, timezone=False):
         super(TIMESTAMP, self).__init__(timezone=timezone)
         self.precision = precision
+
+    def literal_processor(self, dialect):
+        def process(value):
+            if isinstance(value, datetime.datetime):
+                ts = value.strftime("%Y-%m-%d %H:%M:%S")
+                if value.microsecond:
+                    ts += f".{value.microsecond // 1000:03d}"
+                return f"TIMESTAMP '{ts}'"
+            return str(value)
+
+        return process
 
 
 class JSON(TypeDecorator):


### PR DESCRIPTION
## Problem

`TIMESTAMP.literal_processor()` is not implemented, causing a `CompileError` when
`literal_binds=True` is used with a `datetime.datetime` value in a WHERE clause:

```
sqlalchemy.exc.CompileError: No literal value renderer is available for literal value
"datetime.datetime(2026, 6, 17, 9, 57, 43, 244000)" with datatype DATETIME
```

Concrete trigger: Apache Superset's `select_star()` builds a sample query with
`WHERE <partition_col> = <latest_partition_value>` using `literal_binds=True`. Any
table with a TIMESTAMP partition column hits this on the table metadata endpoint.

## Fix

Add `literal_processor` to `TIMESTAMP` emitting a Trino-compatible
`TIMESTAMP 'YYYY-MM-DD HH:MM:SS[.mmm]'` literal.

## Tests

Two unit tests added to `tests/unit/sqlalchemy/test_compiler.py`:
- datetime with sub-second precision → `TIMESTAMP '2026-06-17 09:57:43.244'`
- datetime without microseconds → `TIMESTAMP '2026-06-17 09:57:43'`