### PR TITLE
Return column comments in SQLAlchemy get_columns

### DIFF
--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -671,6 +671,34 @@ def test_get_table_comment(trino_connection):
         metadata.drop_all(engine)
 
 
+@pytest.mark.skipif(
+    trino_version() < 395,
+    reason="Memory connector supports column comments since Trino 395"
+)
+@pytest.mark.parametrize('trino_connection', ['memory'], indirect=True)
+def test_get_columns_with_comments(trino_connection):
+    engine, conn = trino_connection
+
+    if not engine.dialect.has_schema(conn, "test"):
+        with engine.begin() as connection:
+            connection.execute(sqla.schema.CreateSchema("test"))
+
+    table_name = "test.table_with_column_comments"
+    try:
+        conn.execute(sqla.text(
+            f"CREATE TABLE {table_name} ("
+            "id INTEGER COMMENT 'this is the id column', "
+            "name VARCHAR"
+            ")"
+        ))
+        columns = sqla.inspect(engine).get_columns(table_name='table_with_column_comments', schema="test")
+        columns_by_name = {column['name']: column for column in columns}
+        assert columns_by_name['id']['comment'] == 'this is the id column'
+        assert columns_by_name['name']['comment'] is None
+    finally:
+        conn.execute(sqla.text(f"DROP TABLE IF EXISTS {table_name}"))
+
+
 @pytest.mark.parametrize('trino_connection', ['memory/test'], indirect=True)
 @pytest.mark.parametrize('schema', [None, 'test'])
 def test_get_table_names(trino_connection, schema):

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -190,7 +190,8 @@ class TrinoDialect(DefaultDialect):
                 "column_name",
                 "data_type",
                 "column_default",
-                UPPER("is_nullable") AS "is_nullable"
+                UPPER("is_nullable") AS "is_nullable",
+                "comment"
             FROM "information_schema"."columns"
             WHERE "table_schema" = :schema
               AND "table_name" = :table
@@ -205,6 +206,7 @@ class TrinoDialect(DefaultDialect):
                 type=datatype.parse_sqltype(record.data_type),
                 nullable=record.is_nullable == "YES",
                 default=record.column_default,
+                comment=record.comment,
             )
             columns.append(column)
         return columns


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Include the hidden information_schema.columns.comment column in the dialect's _get_columns query so that SQLAlchemy's Inspector.get_columns() exposes column comments via the ReflectedColumn comment field.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fixes #581

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Return column comments in SQLAlchemy get_columns. ({issue}`581`)
```
