### PR TITLE
Send Content-Type charset on statement POST requests

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -169,11 +169,60 @@ def test_request_headers(mock_get_and_post):
 
     req.post("URL")
     _, post_kwargs = post.call_args
-    assert_headers(post_kwargs["headers"])
+    post_headers = post_kwargs["headers"]
+    assert post_headers[constants.HEADER_CONTENT_TYPE] == constants.CONTENT_TYPE_TEXT_UTF8
+    # Content-Type is specific to POST requests. Strip it before reusing the
+    # shared assertions (which count the common headers present on both).
+    del post_headers[constants.HEADER_CONTENT_TYPE]
+    assert_headers(post_headers)
 
     req.get("URL")
     _, get_kwargs = get.call_args
-    assert_headers(get_kwargs["headers"])
+    get_headers = get_kwargs["headers"]
+    assert constants.HEADER_CONTENT_TYPE not in get_headers
+    assert_headers(get_headers)
+
+
+def test_post_sets_content_type_charset(mock_get_and_post):
+    _, post = mock_get_and_post
+
+    req = TrinoRequest(
+        host="coordinator",
+        port=8080,
+        client_session=ClientSession(
+            user="test",
+            source="test",
+            catalog="test",
+            schema="test",
+            properties={},
+        ),
+        http_scheme="http",
+    )
+
+    req.post("SELECT 1")
+    _, post_kwargs = post.call_args
+    assert post_kwargs["headers"][constants.HEADER_CONTENT_TYPE] == constants.CONTENT_TYPE_TEXT_UTF8
+
+
+def test_post_content_type_can_be_overridden(mock_get_and_post):
+    _, post = mock_get_and_post
+
+    req = TrinoRequest(
+        host="coordinator",
+        port=8080,
+        client_session=ClientSession(
+            user="test",
+            source="test",
+            catalog="test",
+            schema="test",
+            properties={},
+        ),
+        http_scheme="http",
+    )
+
+    req.post("SELECT 1", additional_http_headers={constants.HEADER_CONTENT_TYPE: "application/xyz"})
+    _, post_kwargs = post.call_args
+    assert post_kwargs["headers"][constants.HEADER_CONTENT_TYPE] == "application/xyz"
 
 
 def test_request_session_properties_headers(mock_get_and_post):
@@ -232,6 +281,7 @@ def test_additional_request_post_headers(mock_get_and_post):
 
     combined_headers = req.http_headers
     combined_headers.update(additional_headers)
+    combined_headers.setdefault(constants.HEADER_CONTENT_TYPE, constants.CONTENT_TYPE_TEXT_UTF8)
 
     req.post(sql, additional_headers)
 

--- a/trino/client.py
+++ b/trino/client.py
@@ -678,6 +678,10 @@ class TrinoRequest:
         # Update the request headers with the additional_http_headers
         http_headers.update(additional_http_headers or {})
 
+        # The Trino protocol expects UTF-8 encoded SQL text. Send the charset
+        # explicitly to match the Trino JDBC client. Users may still override it.
+        http_headers.setdefault(constants.HEADER_CONTENT_TYPE, constants.CONTENT_TYPE_TEXT_UTF8)
+
         http_response = self._post(
             self.statement_url,
             data=data,

--- a/trino/constants.py
+++ b/trino/constants.py
@@ -40,6 +40,8 @@ HEADER_CLIENT_TAGS = "X-Trino-Client-Tags"
 HEADER_EXTRA_CREDENTIAL = "X-Trino-Extra-Credential"
 HEADER_TIMEZONE = "X-Trino-Time-Zone"
 HEADER_ENCODING = "X-Trino-Query-Data-Encoding"
+HEADER_CONTENT_TYPE = "Content-Type"
+CONTENT_TYPE_TEXT_UTF8 = "text/plain; charset=utf-8"
 
 HEADER_SESSION = "X-Trino-Session"
 HEADER_SET_SESSION = "X-Trino-Set-Session"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Send "text/plain; charset=utf-8" on the statement POST matching the Trino JDBC client (StatementClientV1). The header is set only on POST and uses setdefault so a user-supplied Content-Type still takes precedence.

The client posted the SQL body to /v1/statement without a Content-Type header so no charset was advertised. This breaks Trino Gateway's request analyzer which needs the charset to parse the SQL body for routing rules (it logs "charset is not set in the request" and leaves catalogs/tables/body empty).

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fixes #600

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
