### PR TITLE
Fix compressed spooling: compare decoded length against integer segment sizes

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1716,7 +1716,7 @@ def test_execute_drains_spooled_update_query_with_trailing_page():
             "encoding": "json",
             "segments": [{
                 "type": "inline",
-                "metadata": {"uncompressedSize": "5", "segmentSize": "5"},
+                "metadata": {"uncompressedSize": 5, "segmentSize": 5},
                 "data": encoded_rows,
             }],
         },

--- a/tests/unit/test_client_spooling.py
+++ b/tests/unit/test_client_spooling.py
@@ -14,15 +14,19 @@ import time
 from unittest import mock
 
 import pytest
+import zstandard
 
 from trino.client import _RequestHeartbeat
 from trino.client import ClientSession
 from trino.client import DecodableSegment
 from trino.client import InlineSegment
+from trino.client import JsonQueryDataDecoder
 from trino.client import SegmentIterator
 from trino.client import SpooledSegment
 from trino.client import TrinoQuery
 from trino.client import TrinoRequest
+from trino.client import ZStdQueryDataDecoder
+from trino.mapper import NoOpRowMapper
 
 
 def _mock_trino_request():
@@ -327,3 +331,21 @@ def test_send_spooling_request_segment_header_takes_precedence_over_custom_heade
     segment._send_spooling_request(segment.uri)
 
     assert recorded["headers"]["X-Trino-Spooling-Token"] == "token-abc"
+
+
+def test_zstd_decoder_decodes_compressed_segment_with_string_metadata_sizes():
+    # The spooling protocol reports segmentSize and uncompressedSize as strings
+    # (see _SegmentMetadataTO and the metadata built throughout these tests).
+    # The decoder must compare len(bytes) against those sizes as integers, otherwise
+    # every compressed segment is rejected because an int never equals a decimal string.
+    rows = [[1, "a"], [2, "b"]]
+    uncompressed = json.dumps(rows).encode("utf8")
+    compressed = zstandard.ZstdCompressor().compress(uncompressed)
+
+    metadata = {
+        "segmentSize": str(len(compressed)),
+        "uncompressedSize": str(len(uncompressed)),
+    }
+    decoder = ZStdQueryDataDecoder(JsonQueryDataDecoder(NoOpRowMapper()))
+
+    assert decoder.decode(compressed, metadata) == rows

--- a/tests/unit/test_client_spooling.py
+++ b/tests/unit/test_client_spooling.py
@@ -14,15 +14,19 @@ import time
 from unittest import mock
 
 import pytest
+import zstandard
 
 from trino.client import _RequestHeartbeat
 from trino.client import ClientSession
 from trino.client import DecodableSegment
 from trino.client import InlineSegment
+from trino.client import JsonQueryDataDecoder
 from trino.client import SegmentIterator
 from trino.client import SpooledSegment
 from trino.client import TrinoQuery
 from trino.client import TrinoRequest
+from trino.client import ZStdQueryDataDecoder
+from trino.mapper import NoOpRowMapper
 
 
 def _mock_trino_request():
@@ -176,7 +180,7 @@ def _spooled_fetch_response():
             "segments": [
                 {
                     "type": "inline",
-                    "metadata": {"uncompressedSize": "10", "segmentSize": "10"},
+                    "metadata": {"uncompressedSize": 10, "segmentSize": 10},
                     "data": "",
                 }
             ],
@@ -210,7 +214,7 @@ class _FakeSpooledSegment(SpooledSegment):
                 "type": "spooled",
                 "uri": f"http://storage/{name}",
                 "ackUri": f"http://storage/{name}/ack",
-                "metadata": {"uncompressedSize": "10", "segmentSize": "10"},
+                "metadata": {"uncompressedSize": 10, "segmentSize": 10},
             },
             request=None,
         )
@@ -261,7 +265,7 @@ def _spooled_segment_with_headers(coordinator_host, custom_headers):
         "uri": "https://coordinator/v1/spooled/download/seg1",
         "ackUri": "https://coordinator/v1/spooled/ack/seg1",
         "headers": {"X-Trino-Spooling-Token": ["token-abc"]},
-        "metadata": {"segmentSize": "1", "uncompressedSize": "1"},
+        "metadata": {"segmentSize": 1, "uncompressedSize": 1},
     }
     request = TrinoRequest(
         host="coordinator",
@@ -327,3 +331,32 @@ def test_send_spooling_request_segment_header_takes_precedence_over_custom_heade
     segment._send_spooling_request(segment.uri)
 
     assert recorded["headers"]["X-Trino-Spooling-Token"] == "token-abc"
+
+
+def test_zstd_decoder_decodes_compressed_segment():
+    rows = [[1, "a"], [2, "b"]]
+    uncompressed = json.dumps(rows).encode("utf8")
+    compressed = zstandard.ZstdCompressor().compress(uncompressed)
+
+    metadata = {
+        "segmentSize": len(compressed),
+        "uncompressedSize": len(uncompressed),
+    }
+    decoder = ZStdQueryDataDecoder(JsonQueryDataDecoder(NoOpRowMapper()))
+
+    assert decoder.decode(compressed, metadata) == rows
+
+
+def test_zstd_decoder_rejects_a_segment_whose_size_does_not_match():
+    rows = [[1, "a"]]
+    uncompressed = json.dumps(rows).encode("utf8")
+    compressed = zstandard.ZstdCompressor().compress(uncompressed)
+
+    metadata = {
+        "segmentSize": len(compressed) + 1,
+        "uncompressedSize": len(uncompressed),
+    }
+    decoder = ZStdQueryDataDecoder(JsonQueryDataDecoder(NoOpRowMapper()))
+
+    with pytest.raises(RuntimeError, match="Expected to read"):
+        decoder.decode(compressed, metadata)

--- a/trino/client.py
+++ b/trino/client.py
@@ -1522,11 +1522,11 @@ class CompressedQueryDataDecoder(QueryDataDecoder):
             return self._delegate.decode(data, metadata)
 
         # Data is compressed
-        expected_compressed_size = metadata["segmentSize"]
+        expected_compressed_size = int(metadata["segmentSize"])
         if not len(data) == expected_compressed_size:
             raise RuntimeError(f"Expected to read {expected_compressed_size} bytes but got {len(data)}")
         decompressed_data = self.decompress(data, metadata)
-        expected_uncompressed_size = metadata["uncompressedSize"]
+        expected_uncompressed_size = int(metadata["uncompressedSize"])
         if not len(decompressed_data) == expected_uncompressed_size:
             raise RuntimeError(
                 "Decompressed size does not match expected segment size, "

--- a/trino/client.py
+++ b/trino/client.py
@@ -1196,8 +1196,8 @@ class _SpooledProtocolResponseTO(TypedDict):
 
 
 class _SegmentMetadataTO(TypedDict):
-    uncompressedSize: str
-    segmentSize: str
+    uncompressedSize: int
+    segmentSize: int
 
 
 class _SegmentTO(_SegmentMetadataTO):
@@ -1583,5 +1583,5 @@ class ZStdQueryDataDecoder(CompressedQueryDataDecoder):
 class Lz4QueryDataDecoder(CompressedQueryDataDecoder):
     def decompress(self, data: bytes, metadata: _SegmentMetadataTO) -> bytes:
         expected_uncompressed_size = metadata["uncompressedSize"]
-        decoded_bytes = lz4.block.decompress(data, uncompressed_size=int(expected_uncompressed_size))
+        decoded_bytes = lz4.block.decompress(data, uncompressed_size=expected_uncompressed_size)
         return decoded_bytes


### PR DESCRIPTION
## Description

`CompressedQueryDataDecoder.decode` guards the compressed spooling path by checking the segment length against the sizes the coordinator reports in the segment metadata. Those sizes arrive as strings (the `_SegmentMetadataTO` TypedDict types `segmentSize` and `uncompressedSize` as `str`, and the metadata built across the spooling tests uses string values like `"10"`), but the code compared them directly to `len(data)`, which is an int. An int is never equal to a decimal string, so `not len(data) == metadata["segmentSize"]` is always true and every compressed segment raised `RuntimeError` before it was ever decompressed. The error text gives it away, it reads "Expected to read 29 bytes but got 29" and still raises.

This makes json+zstd and json+lz4 spooling unusable from the client even though both encodings are advertised in the `X-Trino-Encoding` header. The lz4 path already coerces the size with `int(...)` when calling `lz4.block.decompress`, so the two size checks here just needed the same treatment.

The fix wraps both metadata sizes in `int()` before comparing, matching the existing lz4 code. I also added a unit test that decodes a real zstd-compressed segment with the string-typed metadata the protocol actually sends. It fails against the old code with the "expected N, got N" RuntimeError and passes with the fix. The existing spooling tests missed this because they all decode with `encoding="json"` or mock the decoder, so the compressed decode path had no coverage.

## Non-technical explanation

Compressed results returned through the spooling protocol were always rejected with an error. This fixes the size check so compressed segments decode correctly.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Fix decoding of compressed segments in the spooling protocol, which previously failed with a size-mismatch error for every `json+zstd` and `json+lz4` segment.
```
