### PR TITLE
Remove incorrect assertion on "processedRows" cursor stat in a test

### DIFF
--- a/tests/development_server.py
+++ b/tests/development_server.py
@@ -123,6 +123,9 @@ def start_development_server(port=None, trino_version=TRINO_VERSION):
         # Wait for logs indicating the service has started
         wait_for_logs(trino, "SERVER STARTED", timeout=60)
 
+        if (wrapped := trino.get_wrapped_container()) and (image := wrapped.image):
+            print(f"Trino image tags: {image.tags}, digest: {image.id}")
+
         # Otherwise some tests fail with No nodes available
         time.sleep(2)
 

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -1306,7 +1306,6 @@ def test_select_query_stats(trino_connection):
     completed_splits = cur.stats["completedSplits"]
     cpu_time_millis = cur.stats["cpuTimeMillis"]
     processed_bytes = cur.stats["processedBytes"]
-    processed_rows = cur.stats["processedRows"]
     wall_time_millis = cur.stats["wallTimeMillis"]
 
     while cur.fetchone() is not None:
@@ -1314,14 +1313,17 @@ def test_select_query_stats(trino_connection):
         assert completed_splits <= cur.stats["completedSplits"]
         assert cpu_time_millis <= cur.stats["cpuTimeMillis"]
         assert processed_bytes <= cur.stats["processedBytes"]
-        assert processed_rows <= cur.stats["processedRows"]
         assert wall_time_millis <= cur.stats["wallTimeMillis"]
+        # No similar assertion for "processedRows" as it may decrease across responses.
+        # For example, when multiple Trino workers execute a LIMIT query, tasks for some workers
+        # may be cancelled once the row count reaches the limit, which can cause processedRows.
+        # to decrease in a subsequent response (it's an aggregation over active tasks).
+        assert "processedRows" in cur.stats
 
         query_id = cur.stats["queryId"]
         completed_splits = cur.stats["completedSplits"]
         cpu_time_millis = cur.stats["cpuTimeMillis"]
         processed_bytes = cur.stats["processedBytes"]
-        processed_rows = cur.stats["processedRows"]
         wall_time_millis = cur.stats["wallTimeMillis"]
 
 

--- a/tests/integration/test_dbapi_integration.py
+++ b/tests/integration/test_dbapi_integration.py
@@ -1535,11 +1535,20 @@ def retrieve_client_tags_from_query(run_trino, client_tags):
     cur.fetchall()
 
     api_url = "http://" + trino_connection.host + ":" + str(trino_connection.port)
-    query_info = requests.post(api_url + "/ui/login", data={
-        "username": "admin",
-        "password": "",
-        "redirectPath": api_url + '/ui/api/query/' + cur._query.query_id
-    }).json()
+
+    if trino_version() >= 483:
+        session = requests.Session()
+        resp = session.post(api_url + "/ui/auth/login", json={
+            "username": "admin", "password": ""
+        })
+        assert resp.ok, f"POST request to /ui/auth/login failed: {resp.status_code} {resp.reason}"
+        query_info = session.get(api_url + "/ui/api/query/" + cur._query.query_id).json()
+    else:
+        query_info = requests.post(api_url + "/ui/login", data={
+            "username": "admin",
+            "password": "",
+            "redirectPath": api_url + '/ui/api/query/' + cur._query.query_id
+        }).json()
 
     query_client_tags = query_info['session']['clientTags']
     return query_client_tags


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The test `test_select_quert_stats()` is flaky due to an assertion that checks that the "processedRows" cursor stat is non-decreasing across responses. In fact, the stat may decrease, especially for LIMIT queries, as such queries may involve cancelling some Trino worker tasks, and the stat is computed by aggregating over active workers (verified in Trino code).

The PR replaces the incorrect assertion with one that simply checks that "processedRows" exists in the stats.

Some cases when the assertion failed:
- https://github.com/trinodb/trino-python-client/actions/runs/29265674601/job/86870089715?pr=603#step:5:66
- https://github.com/trinodb/trino-python-client/actions/runs/27707800003/job/81960775843#step:5:64
- https://github.com/trinodb/trino-python-client/actions/runs/26816161416/job/79061743155#step:5:64.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

The PR fixes a flaky intergration test by replacing the assertion that checks a property not guaranteed by Trino by a weaker one.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
