### PR TITLE
Fix binding bytes values for VARBINARY columns

### DIFF
--- a/tests/unit/sqlalchemy/test_compiler.py
+++ b/tests/unit/sqlalchemy/test_compiler.py
@@ -15,16 +15,21 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import func
 from sqlalchemy import insert
 from sqlalchemy import Integer
+from sqlalchemy import LargeBinary
+from sqlalchemy import literal
 from sqlalchemy import MetaData
 from sqlalchemy import select
 from sqlalchemy import String
 from sqlalchemy import Table
+from sqlalchemy.exc import CompileError
 from sqlalchemy.exc import SAWarning
 from sqlalchemy.schema import CreateTable
 from sqlalchemy.sql import column
 from sqlalchemy.sql import table
+from sqlalchemy.sql.sqltypes import VARBINARY as GenericVARBINARY
 
 from tests.unit.conftest import sqlalchemy_version
+from trino.sqlalchemy.datatype import VARBINARY
 from trino.sqlalchemy.dialect import TrinoDialect
 
 metadata = MetaData()
@@ -225,3 +230,39 @@ def test_catalogs_create_table_with_unique(dialect):
         statement = CreateTable(table_with_unique)
         query = statement.compile(dialect=dialect)
         assert 'unique' not in str(query).lower()
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        (b'', "X''"),
+        (b'hello', "X'68656c6c6f'"),
+        (b'\xca\xfe\xba\xbe', "X'cafebabe'"),
+        (b'\xff\xfe\x00\x01', "X'fffe0001'"),
+        (bytearray(b'abc'), "X'616263'"),
+        (memoryview(b'abc'), "X'616263'"),
+    ]
+)
+@pytest.mark.parametrize('type_', [VARBINARY(), GenericVARBINARY(), LargeBinary()])
+def test_varbinary_literal_binds(dialect, value, expected, type_):
+    expression = literal(value, type_=type_)
+    query = expression.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    assert str(query) == expected
+
+
+def test_varbinary_literal_binds_rejects_non_bytes(dialect):
+    expression = literal("not-bytes", type_=VARBINARY())
+    with pytest.raises(CompileError):
+        expression.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+
+
+def test_varbinary_create_table():
+    metadata = MetaData()
+    table_with_binary = Table(
+        'table_with_binary',
+        metadata,
+        Column('data', LargeBinary),
+    )
+    statement = CreateTable(table_with_binary)
+    query = statement.compile(dialect=TrinoDialect())
+    assert 'data VARBINARY' in str(query)

--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -31,8 +31,10 @@ from tests.unit.oauth_test_utils import TOKEN_RESOURCE
 from trino import constants
 from trino.auth import BasicAuthentication
 from trino.auth import OAuth2Authentication
+from trino.dbapi import Binary
 from trino.dbapi import connect
 from trino.dbapi import Connection
+from trino.dbapi import Cursor
 
 
 @patch("trino.dbapi.trino.client")
@@ -481,3 +483,45 @@ def test_cursor_close_cancels_unfinished_query():
 
     delete_requests = [r for r in httpretty.latest_requests() if r.method == "DELETE"]
     assert len(delete_requests) == 1, "closing an unfinished query must cancel it"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (b"", b""),
+        (b"hello", b"hello"),
+        (b"\xff\xfe\x00\x01", b"\xff\xfe\x00\x01"),
+        (bytearray(b"abc"), b"abc"),
+        (memoryview(b"xyz"), b"xyz"),
+        ("hello", b"hello"),
+    ]
+)
+def test_binary(value, expected):
+    # Binary() previously called .encode() unconditionally, which raised
+    # AttributeError for bytes/bytearray/memoryview input.
+    result = Binary(value)
+    assert isinstance(result, bytes)
+    assert result == expected
+
+
+@pytest.mark.parametrize("value", [1, None, 1.5, [b"a"]])
+def test_binary_rejects_non_bytes_non_str(value):
+    with pytest.raises(TypeError):
+        Binary(value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (b"", "X''"),
+        (b"hello", "X'68656c6c6f'"),
+        (b"\xca\xfe\xba\xbe", "X'cafebabe'"),
+        (bytearray(b"abc"), "X'616263'"),
+        (memoryview(b"abc"), "X'616263'"),
+    ]
+)
+def test_format_prepared_param_binary(value, expected):
+    cursor = Cursor.__new__(Cursor)
+    assert cursor._format_prepared_param(value) == expected
+    # Round trip through Binary(), as SQLAlchemy's _Binary.bind_processor does.
+    assert cursor._format_prepared_param(Binary(value)) == expected

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -566,8 +566,8 @@ class Cursor:
         if isinstance(param, str):
             return ("'%s'" % param.replace("'", "''"))
 
-        if isinstance(param, (bytes, bytearray)):
-            return "X'%s'" % param.hex()
+        if isinstance(param, (bytes, bytearray, memoryview)):
+            return "X'%s'" % bytes(param).hex()
 
         if isinstance(param, datetime.datetime) and param.tzinfo is None:
             datetime_str = param.strftime("%Y-%m-%d %H:%M:%S.%f")
@@ -811,8 +811,12 @@ def TimeFromTicks(ticks):
     return datetime.time(*datetime.localtime(ticks)[3:6])
 
 
-def Binary(string):
-    return string.encode("utf-8")
+def Binary(value):
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise TypeError(f"Binary() expects bytes, bytearray, memoryview or str, got {type(value).__name__}")
 
 
 class DBAPITypeObject:

--- a/trino/sqlalchemy/datatype.py
+++ b/trino/sqlalchemy/datatype.py
@@ -20,6 +20,7 @@ from typing import Type
 from typing import Union
 
 import sqlalchemy
+from sqlalchemy import exc
 from sqlalchemy import func
 from sqlalchemy import util
 from sqlalchemy.sql import sqltypes
@@ -89,6 +90,21 @@ class JSON(TypeDecorator):
         return func.JSON_PARSE(bindvalue)
 
 
+class VARBINARY(sqltypes.VARBINARY):
+    __visit_name__ = "VARBINARY"
+
+    def literal_processor(self, dialect):
+        def process(value):
+            if isinstance(value, (bytes, bytearray, memoryview)):
+                return f"X'{bytes(value).hex()}'"
+            raise exc.CompileError(
+                f"Could not render literal value {value!r} as a VARBINARY literal, "
+                "expected bytes, bytearray or memoryview"
+            )
+
+        return process
+
+
 class _FormatTypeMixin:
     def _format_value(self, value):
         raise NotImplementedError()
@@ -156,7 +172,7 @@ _type_map = {
     # === String ===
     "varchar": sqltypes.VARCHAR,
     "char": sqltypes.CHAR,
-    "varbinary": sqltypes.VARBINARY,
+    "varbinary": VARBINARY,
     "json": JSON,
     # === Date and time ===
     "date": sqltypes.DATE,

--- a/trino/sqlalchemy/dialect.py
+++ b/trino/sqlalchemy/dialect.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql import sqltypes
 
 from .datatype import JSONIndexType
 from .datatype import JSONPathType
+from .datatype import VARBINARY
 from trino import dbapi as trino_dbapi
 from trino import logging
 from trino.auth import BasicAuthentication
@@ -49,6 +50,10 @@ logger = logging.get_logger(__name__)
 colspecs = {
     sqltypes.JSON.JSONIndexType: JSONIndexType,
     sqltypes.JSON.JSONPathType: JSONPathType,
+    # Applies to sqltypes.LargeBinary, sqltypes.VARBINARY and sqltypes.BINARY, all of which
+    # derive from sqltypes._Binary. Ensures a Trino-compatible X'...' literal is rendered
+    # instead of the default implementation, which assumes the value is UTF-8 decodable text.
+    sqltypes._Binary: VARBINARY,
 }
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
## Description

`Binary()` in `trino/dbapi.py` called `.encode()` on every value unconditionally, raising `AttributeError` for `bytes`/`bytearray`/`memoryview`. It now passes those through as-is.

SQLAlchemy's default `literal_processor` for binary types also renders values as a quoted string, which breaks for non-UTF-8 bytes. Added a `VARBINARY` type in `trino/sqlalchemy/datatype.py` that renders `X'<hex>'`, wired in via `dialect.colspecs` for reflected and generic `LargeBinary`/`BINARY` columns.

## Non-technical explanation

You can now write `bytes` values into a `VARBINARY` column, whether you're using the raw client or SQLAlchemy.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Fix `AttributeError` when binding `bytes` values for `VARBINARY` columns,
  including through SQLAlchemy `LargeBinary` inserts and literal
  compilation.
  ({issue}`626`)
```

Fixes #626