### PR TITLE
Enable type checking for trino.client and trino.dbapi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
     hooks:
       - id: "mypy"
         name: "Python: types"
+        # The hook runs in an isolated environment, so the stubs for the
+        # third-party libraries used in annotated modules must be installed
+        # explicitly, otherwise they resolve to Any and are not checked.
+        additional_dependencies:
+          - "types-requests"
+          - "types-tzlocal"
 
   - repo: "https://github.com/asottile/reorder-python-imports"
     rev: "v3.14.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,10 @@ max-line-length = 120
 ignore = W503
 
 [mypy]
+# trino/client.py annotations use ParamSpec, which only exists in typing from
+# Python 3.10 on. The package still runs on 3.9 (where the annotations are never
+# evaluated, see trino/client.py), but it is not type checked against it.
+python_version = 3.10
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_untyped_calls = true
@@ -18,7 +22,8 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 no_implicit_optional = true
 warn_unused_ignores = true
+warn_redundant_casts = true
 disable_error_code = import-untyped
 
-[mypy-tests.*,trino.client,trino.dbapi,trino.sqlalchemy.*]
+[mypy-tests.*,trino.sqlalchemy.*]
 ignore_errors = true

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ tests_require = all_require + [
     "httpretty < 1.1",
     "pytest",
     "pytest-runner",
+    # Type stubs, so that `mypy trino/` locally matches the pre-commit hook.
+    "types-requests",
+    "types-tzlocal",
     "pre-commit",
     "black",
     "isort",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1336,6 +1336,21 @@ def test_retry_with():
         with_retry(FailerUntil(3).__call__)()
 
 
+@pytest.mark.parametrize("max_attempts", [0, -1])
+def test_max_attempts_below_one_is_rejected(max_attempts):
+    """A single attempt is the minimum; fewer used to fail with an UnboundLocalError
+    on the first request instead of being reported where the value was set.
+    """
+    with pytest.raises(ValueError, match="max_attempts must be at least 1"):
+        TrinoRequest(
+            host="coordinator",
+            port=constants.DEFAULT_TLS_PORT,
+            client_session=ClientSession(user="test"),
+            http_scheme=constants.HTTPS,
+            max_attempts=max_attempts,
+        )
+
+
 def assert_headers_with_roles(headers: Dict[str, str], roles: Optional[str]):
     if roles is None:
         assert constants.HEADER_ROLE not in headers
@@ -1752,3 +1767,43 @@ def test_execute_drains_spooled_update_query_with_trailing_page():
     assert query.stats["state"] == "FINISHED"
     # The count row survives draining and the rows stay lazily iterable.
     assert list(result) == [[3]]
+
+
+@httprettified
+def test_execute_on_a_cancelled_query_reports_the_cancellation():
+    """Re-executing a cancelled TrinoQuery must fail with a readable TrinoUserError."""
+    query_id = "20210817_140827_00000_arvdv"
+    statement_path = f"{SERVER_ADDRESS}{constants.URL_STATEMENT_PATH}"
+    next_uri = f"{statement_path}/{query_id}/1"
+
+    post_response = {
+        "id": query_id,
+        "nextUri": next_uri,
+        "infoUri": f"{SERVER_ADDRESS}/query.html?{query_id}",
+        "columns": [{
+            "name": "x",
+            "type": "bigint",
+            "typeSignature": {"rawType": "bigint", "arguments": [], "typeArguments": []},
+        }],
+        "data": [[1]],
+        "stats": {"state": "RUNNING"},
+    }
+
+    httpretty.register_uri(method=httpretty.POST, uri=statement_path, body=json.dumps(post_response))
+    httpretty.register_uri(method=httpretty.DELETE, uri=next_uri, status=204)
+
+    request = TrinoRequest(
+        host="coordinator",
+        port=constants.DEFAULT_TLS_PORT,
+        client_session=ClientSession(user="test"),
+        http_scheme=constants.HTTPS,
+    )
+    query = TrinoQuery(request, query="SELECT x FROM some_table")
+
+    query.execute()
+    query.cancel()
+    assert query.cancelled is True
+
+    with pytest.raises(trino.exceptions.TrinoUserError, match="Query has been cancelled") as exception_info:
+        query.execute()
+    assert exception_info.value.query_id == query_id

--- a/tests/unit/test_dbapi.py
+++ b/tests/unit/test_dbapi.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import json
 import threading
 import uuid
@@ -35,6 +36,7 @@ from trino.dbapi import Binary
 from trino.dbapi import connect
 from trino.dbapi import Connection
 from trino.dbapi import Cursor
+from trino.dbapi import TimeFromTicks
 
 
 @patch("trino.dbapi.trino.client")
@@ -545,3 +547,32 @@ def test_format_prepared_param_binary(value, expected):
     assert cursor._format_prepared_param(value) == expected
     # Round trip through Binary(), as SQLAlchemy's _Binary.bind_processor does.
     assert cursor._format_prepared_param(Binary(value)) == expected
+
+
+def test_time_from_ticks():
+    """The PEP 249 constructor builds a local time from a Unix timestamp; it used to
+    call a function that does not exist on the datetime module.
+    """
+    ticks = 1700000000
+    expected = datetime.datetime.fromtimestamp(ticks).time().replace(microsecond=0)
+    assert TimeFromTicks(ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "consume",
+    [
+        pytest.param(lambda cursor: iter(cursor), id="iter"),
+        pytest.param(lambda cursor: cursor.fetchone(), id="fetchone"),
+        pytest.param(lambda cursor: cursor.fetchmany(), id="fetchmany"),
+        pytest.param(lambda cursor: cursor.fetchall(), id="fetchall"),
+        pytest.param(lambda cursor: cursor.genall(), id="genall"),
+    ]
+)
+def test_consuming_cursor_without_execute_raises_programming_error(consume):
+    """PEP 249 requires an Error subclass when no execute() produced a result set."""
+    cursor = Cursor.__new__(Cursor)
+    cursor._iterator = None
+    cursor._query = None
+    cursor.arraysize = 1
+    with pytest.raises(trino.exceptions.ProgrammingError, match="execute\\(\\) has not been called"):
+        consume(cursor)

--- a/trino/auth.py
+++ b/trino/auth.py
@@ -438,7 +438,7 @@ class _OAuth2TokenBearer(AuthBase):
         if token is not None:
             r.headers['Authorization'] = "Bearer " + token
 
-        r.register_hook('response', self._authenticate)
+        r.register_hook('response', self._authenticate)  # type: ignore[no-untyped-call]
 
         return r
 
@@ -500,8 +500,9 @@ class _OAuth2TokenBearer(AuthBase):
 
     def _retry_request(self, response: Response, **kwargs: Any) -> Optional[Response]:
         request = response.request.copy()
-        extract_cookies_to_jar(request._cookies, response.request, response.raw)
-        request.prepare_cookies(request._cookies)
+        cookies = request._cookies  # type: ignore[attr-defined]  # no `_cookies` in type stubs for `requests`
+        extract_cookies_to_jar(cookies, response.request, response.raw)  # type: ignore[no-untyped-call]
+        request.prepare_cookies(cookies)
 
         host = self._determine_host(response.request.url)
         user = self._determine_user(request.headers)

--- a/trino/client.py
+++ b/trino/client.py
@@ -48,6 +48,8 @@ import urllib.parse
 import warnings
 from abc import abstractmethod
 from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
@@ -61,7 +63,9 @@ from typing import Dict
 from typing import List
 from typing import Literal
 from typing import Optional
+from typing import Protocol
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing import Union
 from zoneinfo import ZoneInfo
@@ -69,14 +73,19 @@ from zoneinfo import ZoneInfo
 try:
     import lz4.block
 except ImportError as err:
-    _LZ4_ERROR = str(err)
+    _LZ4_ERROR: Optional[str] = str(err)
 else:
     _LZ4_ERROR = None
 
-try:
-    import orjson as json
-except ImportError:
+if TYPE_CHECKING:
+    # orjson has no stubs and is API-compatible with the standard library for
+    # the loads() calls made here, so type checking goes against json.
     import json
+else:
+    try:
+        import orjson as json
+    except ImportError:
+        import json
 
 import requests
 from requests import Response
@@ -86,7 +95,7 @@ from requests.structures import CaseInsensitiveDict
 try:
     import zstandard
 except ImportError as err:
-    _ZSTD_ERROR = str(err)
+    _ZSTD_ERROR: Optional[str] = str(err)
 else:
     _ZSTD_ERROR = None
 
@@ -99,6 +108,7 @@ from trino.auth import Authentication
 from trino.exceptions import TrinoExternalError
 from trino.exceptions import TrinoQueryError
 from trino.exceptions import TrinoUserError
+from trino.mapper import NoOpRowMapper
 from trino.mapper import RowMapper
 from trino.mapper import RowMapperFactory
 
@@ -114,11 +124,22 @@ __all__ = [
     "Segment"
 ]
 
+_AnyRowMapper = Union[RowMapper, NoOpRowMapper]
+
+if TYPE_CHECKING:
+    # ParamSpec is defined in Python >=3.10, so the module won't type check with older versions
+    from typing import ParamSpec
+    from typing import TypeVar
+
+    # Type vars for _retry_with and RetryHandler
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R", bound=Response)
+
 logger = trino.logging.get_logger(__name__)
 executor = ThreadPoolExecutor(max_workers=4)
 
 
-def close_executor():
+def close_executor() -> None:
     executor.shutdown(wait=True)
 
 
@@ -182,17 +203,17 @@ class ClientSession:
 
     def __init__(
         self,
-        user: str,
+        user: Optional[str],
         authorization_user: Optional[str] = None,
         catalog: Optional[str] = None,
         schema: Optional[str] = None,
         source: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[Dict[str, Union[str, bytes]]] = None,
         transaction_id: Optional[str] = None,
-        extra_credential: Optional[List[Tuple[str, str]]] = None,
-        client_tags: Optional[List[str]] = None,
-        roles: Optional[Union[Dict[str, str], str]] = None,
+        extra_credential: Optional[Sequence[Tuple[str, str]]] = None,
+        client_tags: Optional[Sequence[str]] = None,
+        roles: Optional[Union[Mapping[str, str], str]] = None,
         timezone: Optional[str] = None,
         encoding: Optional[Union[str, List[str]]] = None,
         heartbeat_interval: Optional[float] = constants.DEFAULT_HEARTBEAT_INTERVAL,
@@ -209,7 +230,7 @@ class ClientSession:
         self._headers = headers.copy() if headers is not None else {}
         self._transaction_id = transaction_id
         self._extra_credential = extra_credential
-        self._client_tags = client_tags.copy() if client_tags is not None else list()
+        self._client_tags = list(client_tags) if client_tags is not None else []
         self._roles = self._format_roles(roles) if roles is not None else {}
         if timezone:  # Check timezone validity
             ZoneInfo(timezone)
@@ -221,7 +242,7 @@ class ClientSession:
         self._heartbeat_interval = heartbeat_interval
 
     @property
-    def user(self) -> str:
+    def user(self) -> Optional[str]:
         return self._user
 
     @property
@@ -269,7 +290,7 @@ class ClientSession:
             self._properties = properties
 
     @property
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> Dict[str, Union[str, bytes]]:
         return self._headers
 
     @property
@@ -283,7 +304,7 @@ class ClientSession:
             self._transaction_id = transaction_id
 
     @property
-    def extra_credential(self) -> Optional[List[Tuple[str, str]]]:
+    def extra_credential(self) -> Optional[Sequence[Tuple[str, str]]]:
         return self._extra_credential
 
     @property
@@ -324,7 +345,7 @@ class ClientSession:
         return self._heartbeat_interval
 
     @staticmethod
-    def _format_roles(roles: Union[Dict[str, str], str]) -> Dict[str, str]:
+    def _format_roles(roles: Union[Mapping[str, str], str]) -> Dict[str, str]:
         if isinstance(roles, str):
             roles = {"system": roles}
         formatted_roles = {}
@@ -341,12 +362,12 @@ class ClientSession:
                 formatted_roles[catalog] = f"ROLE{{{role}}}"
         return formatted_roles
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         del state["_object_lock"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         self.__dict__.update(state)
         self._object_lock = threading.Lock()
 
@@ -391,7 +412,7 @@ class TrinoStatus:
     rows: Union[List[Any], Dict[str, Any]]
     columns: List[Any]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "TrinoStatus("
             "id={}, stats={{...}}, warnings={}, info_uri={}, next_uri={}, rows=<count={}>"
@@ -407,14 +428,18 @@ class TrinoStatus:
 
 class _DelayExponential:
     def __init__(
-            self, base=0.1, exponent=2, jitter=True, max_delay=1800  # 100ms  # 30 min
-    ):
+            self,
+            base: float = 0.1,  # 100ms
+            exponent: float = 2,
+            jitter: bool = True,
+            max_delay: float = 1800,  # 30 min
+    ) -> None:
         self._base = base
         self._exponent = exponent
         self._jitter = jitter
         self._max_delay = max_delay
 
-    def __call__(self, attempt):
+    def __call__(self, attempt: int) -> float:
         delay = float(self._base) * (self._exponent ** attempt)
         if self._jitter:
             delay *= random.random()
@@ -422,22 +447,46 @@ class _DelayExponential:
         return delay
 
 
-class _RetryWithExponentialBackoff:
+class RetryHandler(Protocol):
+
+    def retry(
+        self,
+        func: Callable[_P, Response],
+        args: _P.args,
+        kwargs: _P.kwargs,
+        err: Optional[BaseException],
+        attempt: int,
+    ) -> None:
+        """Sleep before the next attempt.
+
+        Called with the function being retried, the arguments it was called with, the exception that triggered
+        the retry (`None` when the retry was triggered by the response) and the number of the attempt that just failed.
+        """
+        ...
+
+
+class _RetryWithExponentialBackoff(RetryHandler):
     def __init__(
-            self, base=0.1, exponent=2, jitter=True, max_delay=1800  # 100ms  # 30 min
-    ):
+            self,
+            base: float = 0.1,  # 100ms
+            exponent: float = 2,
+            jitter: bool = True,
+            max_delay: float = 1800,  # 30 min
+    ) -> None:
         self._get_delay = _DelayExponential(base, exponent, jitter, max_delay)
 
-    def retry(self, func, args, kwargs, err, attempt):
+    def retry(
+        self, func: object, args: object, kwargs: object, err: object, attempt: int
+    ) -> None:
         delay = self._get_delay(attempt)
         sleep(delay)
 
 
 class _RetryAfterSleep:
-    def __init__(self, retry_after_header):
+    def __init__(self, retry_after_header: float) -> None:
         self._retry_after_header = retry_after_header
 
-    def retry(self):
+    def retry(self) -> None:
         sleep(self._retry_after_header)
 
 
@@ -499,8 +548,8 @@ class TrinoRequest:
         auth: Optional[Authentication] = constants.DEFAULT_AUTH,
         max_attempts: int = MAX_ATTEMPTS,
         request_timeout: Union[float, Tuple[float, float]] = constants.DEFAULT_REQUEST_TIMEOUT,
-        handle_retry=_RetryWithExponentialBackoff(),
-        verify: bool = True,
+        handle_retry: RetryHandler = _RetryWithExponentialBackoff(),
+        verify: Optional[Union[bool, str]] = True,
     ) -> None:
         self._client_session = client_session
         self._host = host
@@ -540,8 +589,9 @@ class TrinoRequest:
         self._client_session.transaction_id = value
 
     @property
-    def http_headers(self) -> CaseInsensitiveDict[str]:
-        headers: CaseInsensitiveDict[str] = CaseInsensitiveDict()
+    def http_headers(self) -> CaseInsensitiveDict[Any]:
+        # A None value means "do not send this header"; requests drops those.
+        headers: CaseInsensitiveDict[Any] = CaseInsensitiveDict()
 
         headers[constants.HEADER_CATALOG] = self._client_session.catalog
         headers[constants.HEADER_SCHEMA] = self._client_session.schema
@@ -618,7 +668,7 @@ class TrinoRequest:
 
         return headers
 
-    def unauthenticated(self):
+    def unauthenticated(self) -> TrinoRequest:
         return TrinoRequest(
             host=self._host,
             port=self._port,
@@ -715,7 +765,9 @@ class TrinoRequest:
         )
 
     @staticmethod
-    def _process_error(error, query_id: Optional[str]) -> Union[TrinoExternalError, TrinoQueryError, TrinoUserError]:
+    def _process_error(
+        error: Dict[str, Any], query_id: Optional[str]
+    ) -> Union[TrinoExternalError, TrinoQueryError, TrinoUserError]:
         error_type = error["errorType"]
         if error_type == "EXTERNAL":
             raise exceptions.TrinoExternalError(error, query_id)
@@ -738,7 +790,7 @@ class TrinoRequest:
         raise exceptions.HttpError(
             "error {}{}".format(
                 http_response.status_code,
-                ": {}".format(http_response.content) if http_response.content else "",
+                ": {!r}".format(http_response.content) if http_response.content else "",
             )
         )
 
@@ -842,10 +894,11 @@ class TrinoResult:
     failure happened instead of silently dropping the remaining rows.
     """
 
-    def __init__(self, query, rows: List[Any]):
+    def __init__(self, query: TrinoQuery, rows: Any) -> None:
         self._query = query
-        # Initial rows from the first POST request
-        self._rows = rows
+        # Initial rows from the first POST request. Depending on the protocol these
+        # are a list, a lazy iterator over spooled segments, or None once exhausted.
+        self._rows: Any = rows
         self._rownumber = 0
         # Iterator over the batch of rows currently being served
         self._current_batch: Optional[Iterator[Any]] = None
@@ -853,21 +906,21 @@ class TrinoResult:
         self._next_rows: Optional[Any] = None
 
     @property
-    def rows(self):
+    def rows(self) -> Any:
         return self._rows
 
     @rows.setter
-    def rows(self, rows):
+    def rows(self, rows: Any) -> None:
         self._rows = rows
 
     @property
     def rownumber(self) -> int:
         return self._rownumber
 
-    def __iter__(self):
+    def __iter__(self) -> TrinoResult:
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         while True:
             if self._current_batch is None:
                 if self._query.finished and self._rows is None:
@@ -904,17 +957,17 @@ class TrinoQuery:
         self._stats: Dict[Any, Any] = {}
         self._info_uri: Optional[str] = None
         self._warnings: List[Dict[Any, Any]] = []
-        self._columns: Optional[List[str]] = None
+        self._columns: Optional[List[Dict[str, Any]]] = None
         self._finished = False
         self._cancelled = False
         self._request = request
-        self._update_type = None
-        self._update_count = None
-        self._next_uri = None
+        self._update_type: Optional[str] = None
+        self._update_count: Optional[int] = None
+        self._next_uri: Optional[str] = None
         self._query = query
         self._result: Optional[TrinoResult] = None
         self._legacy_primitive_types = legacy_primitive_types
-        self._row_mapper: Optional[RowMapper] = None
+        self._row_mapper: Optional[_AnyRowMapper] = None
         self._fetch_mode = fetch_mode
         self._stats_callback = stats_callback
 
@@ -927,8 +980,10 @@ class TrinoQuery:
         return self._query
 
     @property
-    def columns(self):
-        if self.query_id:
+    def columns(self) -> Optional[List[Dict[str, Any]]]:
+        # execute() sets the query id and the result together.
+        if self.query_id and self._result is not None:
+            result = self._result
             while not self._columns and not self.finished and not self.cancelled:
                 # Columns are not returned immediately after query is submitted.
                 # Continue fetching data until columns information is available and push fetched rows into buffer.
@@ -939,41 +994,41 @@ class TrinoQuery:
                 #    because we cannot cheaply check iterator length.
                 new_rows = self.fetch()
                 if isinstance(new_rows, list):
-                    self._result.rows += new_rows
+                    result.rows += new_rows
                 else:
                     try:
                         first_row = next(new_rows)
-                        self._result.rows = itertools.chain([first_row], new_rows)
+                        result.rows = itertools.chain([first_row], new_rows)
                         break
                     except StopIteration:
-                        self._result.rows = []
+                        result.rows = []
         return self._columns
 
     @property
-    def stats(self):
+    def stats(self) -> Dict[Any, Any]:
         return self._stats
 
     @property
-    def update_type(self):
+    def update_type(self) -> Optional[str]:
         return self._update_type
 
     @property
-    def update_count(self):
+    def update_count(self) -> Optional[int]:
         return self._update_count
 
     @property
-    def warnings(self):
+    def warnings(self) -> List[Dict[Any, Any]]:
         return self._warnings
 
     @property
-    def result(self):
+    def result(self) -> Optional[TrinoResult]:
         return self._result
 
     @property
-    def info_uri(self):
+    def info_uri(self) -> Optional[str]:
         return self._info_uri
 
-    def execute(self, additional_http_headers=None) -> TrinoResult:
+    def execute(self, additional_http_headers: Optional[Dict[str, Any]] = None) -> TrinoResult:
         """Initiate a Trino query by sending the SQL statement
 
         This is the first HTTP request sent to the coordinator.
@@ -982,7 +1037,7 @@ class TrinoQuery:
         call fetch() until finished is true.
         """
         if self.cancelled:
-            raise exceptions.TrinoUserError("Query has been cancelled", self.query_id)
+            raise exceptions.TrinoUserError({"message": "Query has been cancelled"}, self.query_id)
 
         try:
             response = self._request.post(self._query, additional_http_headers)
@@ -997,7 +1052,7 @@ class TrinoQuery:
         if status.next_uri is None:
             self._finished = True
 
-        rows = self._row_mapper.map(status.rows) if self._row_mapper else status.rows
+        rows = self._row_mapper.map(cast(List[List[Any]], status.rows)) if self._row_mapper else status.rows
         self._result = TrinoResult(self, rows)
 
         # Block until rows are available, the query finishes, or it is canceled.
@@ -1040,7 +1095,7 @@ class TrinoQuery:
 
         return self._result
 
-    def _update_state(self, status):
+    def _update_state(self, status: TrinoStatus) -> None:
         self._stats.update(status.stats)
         self._update_type = status.update_type
         self._update_count = status.update_count
@@ -1057,10 +1112,12 @@ class TrinoQuery:
             # Pass a deep copy so the callback cannot mutate internal query state.
             self._stats_callback(copy.deepcopy(self._stats))
 
-    def fetch(self) -> Union[List[Union[List[Any], Any]], Iterator[List[Any]]]:
+    def fetch(self) -> Union[List[Any], Iterator[List[Any]]]:
         """Continue fetching data for the current query_id"""
+        # fetch() is only called while the query still has a next URI to poll.
+        next_uri = cast(str, self._request.next_uri)
         try:
-            response = self._request.get(self._request.next_uri)
+            response = self._request.get(next_uri)
         except requests.exceptions.RequestException as e:
             raise trino.exceptions.TrinoConnectionError("failed to fetch: {}".format(e))
         status = self._request.process(response)
@@ -1071,11 +1128,9 @@ class TrinoQuery:
         if not self._row_mapper:
             return []
 
-        rows = status.rows
         if isinstance(status.rows, dict):
             # spooling protocol
-            rows = cast(_SpooledProtocolResponseTO, rows)
-            spooled = self._to_segments(rows)
+            spooled = self._to_segments(cast(_SpooledProtocolResponseTO, status.rows))
             if self._fetch_mode == "segments":
                 return spooled
             # Return iterator directly, do NOT materialize with list()
@@ -1086,14 +1141,14 @@ class TrinoQuery:
                 heartbeat_interval=self._request._client_session.heartbeat_interval,
             )
         elif isinstance(status.rows, list):
-            return self._row_mapper.map(rows)
+            return self._row_mapper.map(cast(List[List[Any]], status.rows))
         else:
             raise ValueError(f"Unexpected type: {type(status.rows)}")
 
     def _to_segments(self, rows: _SpooledProtocolResponseTO) -> List[DecodableSegment]:
         encoding = rows["encoding"]
         metadata = rows["metadata"] if "metadata" in rows else None
-        segments = []
+        segments: List[Segment] = []
         for segment in rows["segments"]:
             segment_type = segment["type"]
             if segment_type == SegmentType.INLINE:
@@ -1143,18 +1198,26 @@ class TrinoQuery:
         return self._cancelled
 
 
-def _retry_with(handle_retry, handled_exceptions, conditions, max_attempts):
-    def wrapper(func):
+def _retry_with(
+    handle_retry: RetryHandler,
+    handled_exceptions: Tuple[Any, ...],
+    conditions: Tuple[Callable[[Any], bool], ...],
+    max_attempts: int,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be at least 1, got {max_attempts}")
+
+    def wrapper(func: Callable[_P, _R]) -> Callable[_P, _R]:
         @functools.wraps(func)
-        def decorated(*args, **kwargs):
-            error = None
-            result = None
+        def decorated(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            error: Optional[BaseException] = None
+            result: Optional[_R] = None
             for attempt in range(1, max_attempts + 1):
                 try:
                     result = func(*args, **kwargs)
                     if any(guard(result) for guard in conditions):
                         if result.status_code == 429 and "Retry-After" in result.headers:
-                            retry_after = _parse_retry_after_header(result.headers.get("Retry-After"))
+                            retry_after = _parse_retry_after_header(result.headers["Retry-After"])
                             handle_retry_sleep = _RetryAfterSleep(retry_after)
                             handle_retry_sleep.retry()
                         else:
@@ -1170,14 +1233,16 @@ def _retry_with(handle_retry, handled_exceptions, conditions, max_attempts):
             logger.info("failed after %s attempts", attempt)
             if error is not None:
                 raise error
-            return result
+            # max_attempts is at least 1, so the loop ran and `result` holds the
+            # response of the last attempt, which a retry condition matched.
+            return cast("_R", result)
 
         return decorated
 
     return wrapper
 
 
-def _parse_retry_after_header(retry_after):
+def _parse_retry_after_header(retry_after: Union[int, str]) -> float:
     if isinstance(retry_after, int):
         return retry_after
     elif isinstance(retry_after, str) and retry_after.isdigit():
@@ -1234,7 +1299,7 @@ class Segment(abc.ABC):
 
     @property
     @abstractmethod
-    def data(self):
+    def data(self) -> bytes:
         pass
 
     @property
@@ -1252,13 +1317,13 @@ class InlineSegment(Segment):
     """
     def __init__(self, segment: _InlineSegmentTO) -> None:
         super().__init__(segment)
-        self._segment = cast(_InlineSegmentTO, segment)
+        self._segment: _InlineSegmentTO = segment
 
     @property
     def data(self) -> bytes:
         return base64.b64decode(self._segment["data"])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"InlineSegment(metadata={self.metadata})"
 
 
@@ -1285,7 +1350,7 @@ class SpooledSegment(Segment):
         custom_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__(segment)
-        self._segment = cast(_SpooledSegmentTO, segment)
+        self._segment: _SpooledSegmentTO = segment
         self._request = request
         self._coordinator_host = coordinator_host
         self._custom_headers = custom_headers or {}
@@ -1310,7 +1375,7 @@ class SpooledSegment(Segment):
         return self._segment.get("headers", {})
 
     def acknowledge(self) -> None:
-        def acknowledge_request():
+        def acknowledge_request() -> None:
             try:
                 http_response = self._send_spooling_request(self.ack_uri, timeout=2)
                 if not http_response.ok:
@@ -1320,7 +1385,7 @@ class SpooledSegment(Segment):
         # Start the acknowledgment in the executor thread
         executor.submit(acknowledge_request)
 
-    def _send_spooling_request(self, uri: str, **kwargs) -> requests.Response:
+    def _send_spooling_request(self, uri: str, **kwargs: Any) -> requests.Response:
         headers: Dict[str, str] = {}
         # Forward user-supplied custom headers (e.g. auth gateway headers) only when the
         # request targets the Trino coordinator, never to external storage (e.g. S3 presigned
@@ -1334,7 +1399,7 @@ class SpooledSegment(Segment):
             headers[key] = values[0]
         return self._request._get(uri, headers=headers, **kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"SpooledSegment(metadata={self.metadata})"
         )
@@ -1355,18 +1420,18 @@ class DecodableSegment:
         self._segment = segment
 
     @property
-    def encoding(self):
+    def encoding(self) -> str:
         return self._encoding
 
     @property
-    def segment(self):
+    def segment(self) -> Segment:
         return self._segment
 
     @property
-    def metadata(self):
+    def metadata(self) -> _SegmentMetadataTO:
         return self._metadata
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f"DecodableSegment(encoding={self._encoding}, metadata={self._metadata}, segment={self._segment})")
 
 
@@ -1388,7 +1453,7 @@ class _RequestHeartbeat:
         threading.Thread(target=self._run, daemon=True).start()
         return self
 
-    def __exit__(self, *_) -> None:
+    def __exit__(self, *_: Any) -> None:
         self._stop_event.set()
 
     def _run(self) -> None:
@@ -1426,14 +1491,14 @@ class SegmentIterator:
     def __init__(
         self,
         segments: Union[DecodableSegment, List[DecodableSegment]],
-        mapper: RowMapper,
+        mapper: _AnyRowMapper,
         *,
         request: Optional[TrinoRequest] = None,
         heartbeat_interval: Optional[float] = None,
     ) -> None:
         self._segments = iter(segments if isinstance(segments, List) else [segments])
         self._mapper = mapper
-        self._decoder = None
+        self._decoder: Optional[SegmentDecoder] = None
         self._rows: Iterator[List[List[Any]]] = iter([])
         self._finished = False
         self._current_segment: Optional[DecodableSegment] = None
@@ -1457,7 +1522,7 @@ class SegmentIterator:
                     raise StopIteration
                 self._load_next_segment()
 
-    def _load_next_segment(self):
+    def _load_next_segment(self) -> None:
         # A segment is acknowledged only after its rows were decoded successfully. If the previous attempt failed
         # mid-decode (e.g. the spooled segment download failed) the same segment is retried instead of being skipped.
         if self._pending_segment is None:
@@ -1495,18 +1560,14 @@ class SegmentDecoder():
         self._decoder = decoder
 
     def decode(self, segment: Segment) -> List[List[Any]]:
-        if isinstance(segment, InlineSegment):
-            inline_segment = cast(InlineSegment, segment)
-            return self._decoder.decode(inline_segment.data, inline_segment.metadata)
-        elif isinstance(segment, SpooledSegment):
-            spooled_data = cast(SpooledSegment, segment)
-            return self._decoder.decode(spooled_data.data, spooled_data.metadata)
+        if isinstance(segment, (InlineSegment, SpooledSegment)):
+            return self._decoder.decode(segment.data, segment.metadata)
         else:
             raise ValueError(f"Unsupported segment type: {type(segment)}")
 
 
 class CompressedQueryDataDecoderFactory():
-    def __init__(self, mapper: RowMapper) -> None:
+    def __init__(self, mapper: _AnyRowMapper) -> None:
         self._mapper = mapper
 
     def create(self, encoding: str) -> QueryDataDecoder:
@@ -1535,10 +1596,10 @@ class QueryDataDecoder(abc.ABC):
 
 
 class JsonQueryDataDecoder(QueryDataDecoder):
-    def __init__(self, mapper: RowMapper) -> None:
+    def __init__(self, mapper: _AnyRowMapper) -> None:
         self._mapper = mapper
 
-    def decode(self, data: bytes, metadata: Dict[str, Any]) -> List[List[Any]]:
+    def decode(self, data: bytes, metadata: _SegmentMetadataTO) -> List[List[Any]]:
         return self._mapper.map(json.loads(data.decode("utf8")))
 
 
@@ -1572,7 +1633,7 @@ class CompressedQueryDataDecoder(QueryDataDecoder):
 class ZStdQueryDataDecoder(CompressedQueryDataDecoder):
     def __init__(self, delegate: QueryDataDecoder) -> None:
         super().__init__(delegate)
-        self._decompressor = None
+        self._decompressor: Optional[zstandard.ZstdDecompressor] = None
 
     def decompress(self, data: bytes, metadata: _SegmentMetadataTO) -> bytes:
         if self._decompressor is None:

--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -17,13 +17,19 @@ https://www.python.org/dev/peps/pep-0249/ .
 Fetch methods returns rows as a list of lists on purpose to let the caller
 decide to convert then to a list of tuples.
 """
+from __future__ import annotations
+
 import datetime
 import math
 import uuid
 from collections import OrderedDict
+from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from decimal import Decimal
 from itertools import islice
 from threading import Lock
+from time import localtime
 from time import time
 from typing import Any
 from typing import Callable
@@ -31,14 +37,18 @@ from typing import Dict
 from typing import List
 from typing import NamedTuple
 from typing import Optional
+from typing import Tuple
 from typing import Union
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
+
+from requests import Session
 
 import trino.client
 import trino.exceptions
 import trino.logging
 from trino import constants
+from trino.auth import Authentication
 from trino.constants import LENGTH_TYPES
 from trino.constants import PRECISION_TYPES
 from trino.constants import SCALE_TYPES
@@ -89,13 +99,14 @@ class TimeBoundLRUCache:
     """A bounded LRU cache which expires entries after a configured number of seconds.
     Note that expired entries will be evicted only on an attempted access (or through
     the LRU policy)."""
-    def __init__(self, capacity: int, ttl_seconds: int):
+    def __init__(self, capacity: int, ttl_seconds: int) -> None:
         self.capacity = capacity
         self.ttl_seconds = ttl_seconds
-        self.cache = OrderedDict()
+        # Maps key -> (value, insertion timestamp)
+        self.cache: "OrderedDict[object, Tuple[Any, float]]" = OrderedDict()
         self.lock = Lock()
 
-    def get(self, key):
+    def get(self, key: object) -> Any:
         with self.lock:
             if key not in self.cache:
                 return None
@@ -106,21 +117,21 @@ class TimeBoundLRUCache:
             self.cache.move_to_end(key)
             return value
 
-    def put(self, key, value):
+    def put(self, key: object, value: Any) -> None:
         with self.lock:
             self.cache[key] = value, time()
             self.cache.move_to_end(key)
             if len(self.cache) > self.capacity:
                 self.cache.popitem(last=False)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"LRUCache(capacity: {self.capacity}, ttl: {self.ttl_seconds} seconds, {self.cache})"
 
 
 must_use_legacy_prepared_statements = TimeBoundLRUCache(1024, 3600)
 
 
-def connect(*args, **kwargs):
+def connect(*args: Any, **kwargs: Any) -> Connection:
     """Constructor for creating a connection to the database.
 
     See class :py:class:`Connection` for arguments.
@@ -130,7 +141,7 @@ def connect(*args, **kwargs):
     return Connection(*args, **kwargs)
 
 
-_USE_DEFAULT_ENCODING = object()
+_USE_DEFAULT_ENCODING: Any = object()
 
 
 class Connection:
@@ -144,30 +155,30 @@ class Connection:
     def __init__(
         self,
         host: str,
-        port=None,
-        user=None,
-        source=constants.DEFAULT_SOURCE,
-        catalog=constants.DEFAULT_CATALOG,
-        schema=constants.DEFAULT_SCHEMA,
-        session_properties=None,
-        http_headers=None,
-        http_scheme=None,
-        auth=constants.DEFAULT_AUTH,
-        extra_credential=None,
-        max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
-        request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
-        isolation_level=IsolationLevel.AUTOCOMMIT,
-        verify=True,
-        http_session=None,
-        client_tags=None,
-        legacy_primitive_types=False,
-        legacy_prepared_statements=None,
-        roles=None,
-        timezone=None,
+        port: Optional[Union[int, str]] = None,
+        user: Optional[str] = None,
+        source: Optional[str] = constants.DEFAULT_SOURCE,
+        catalog: Optional[str] = constants.DEFAULT_CATALOG,
+        schema: Optional[str] = constants.DEFAULT_SCHEMA,
+        session_properties: Optional[Dict[str, Any]] = None,
+        http_headers: Optional[Dict[str, Union[str, bytes]]] = None,
+        http_scheme: Optional[str] = None,
+        auth: Optional[Authentication] = constants.DEFAULT_AUTH,
+        extra_credential: Optional[Sequence[Tuple[str, Any]]] = None,
+        max_attempts: int = constants.DEFAULT_MAX_ATTEMPTS,
+        request_timeout: Union[float, Tuple[float, float]] = constants.DEFAULT_REQUEST_TIMEOUT,
+        isolation_level: IsolationLevel = IsolationLevel.AUTOCOMMIT,
+        verify: Optional[Union[bool, str]] = True,
+        http_session: Optional[Session] = None,
+        client_tags: Optional[Sequence[str]] = None,
+        legacy_primitive_types: bool = False,
+        legacy_prepared_statements: Optional[bool] = None,
+        roles: Optional[Union[Mapping[str, str], str]] = None,
+        timezone: Optional[str] = None,
         encoding: Union[str, List[str]] = _USE_DEFAULT_ENCODING,
         heartbeat_interval: Optional[float] = constants.DEFAULT_HEARTBEAT_INTERVAL,
         allow_insecure_auth: bool = False,
-    ):
+    ) -> None:
         # Automatically assign http_schema, port based on hostname
         parsed_host = urlparse(host, allow_fragments=False)
 
@@ -233,9 +244,9 @@ class Connection:
         # Infer connection port: `hostname` takes precedence over explicit `port` argument
         # If none is given, use default based on HTTP protocol
         default_port = constants.DEFAULT_TLS_PORT if self.http_scheme == constants.HTTPS else constants.DEFAULT_PORT
-        self.port = (
+        self.port: int = (
             parsed_host.port if parsed_host.port is not None
-            else port if port is not None
+            else int(port) if port is not None
             else default_port
         )
 
@@ -246,23 +257,23 @@ class Connection:
         self.client_tags = client_tags
 
         self._isolation_level = isolation_level
-        self._request = None
-        self._transaction = None
+        self._request: Optional[trino.client.TrinoRequest] = None
+        self._transaction: Optional[Transaction] = None
         self.legacy_primitive_types = legacy_primitive_types
         self.legacy_prepared_statements = legacy_prepared_statements
 
     @property
-    def isolation_level(self):
+    def isolation_level(self) -> IsolationLevel:
         return self._isolation_level
 
     @property
-    def transaction(self):
+    def transaction(self) -> Optional[Transaction]:
         return self._transaction
 
-    def __enter__(self):
+    def __enter__(self) -> Connection:
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         try:
             self.commit()
         except Exception:
@@ -270,28 +281,28 @@ class Connection:
         else:
             self.close()
 
-    def close(self):
+    def close(self) -> None:
         # TODO cancel outstanding queries?
         self._http_session.close()
 
-    def start_transaction(self):
+    def start_transaction(self) -> Transaction:
         self._transaction = Transaction(self._create_request())
         self._transaction.begin()
         return self._transaction
 
-    def commit(self):
-        if self.transaction is None:
+    def commit(self) -> None:
+        if self._transaction is None:
             return
         self._transaction.commit()
         self._transaction = None
 
-    def rollback(self):
-        if self.transaction is None:
+    def rollback(self) -> None:
+        if self._transaction is None:
             raise RuntimeError("no transaction was started")
         self._transaction.rollback()
         self._transaction = None
 
-    def _create_request(self):
+    def _create_request(self) -> trino.client.TrinoRequest:
         return trino.client.TrinoRequest(
             self.host,
             self.port,
@@ -306,8 +317,8 @@ class Connection:
     def cursor(
             self,
             cursor_style: str = "row",
-            legacy_primitive_types: bool = None,
-            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
+            legacy_primitive_types: Optional[bool] = None,
+            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> Cursor:
         """Return a new :py:class:`Cursor` object using the connection."""
         if self.isolation_level != IsolationLevel.AUTOCOMMIT:
             if self.transaction is None:
@@ -334,7 +345,7 @@ class Connection:
             stats_callback=stats_callback
         )
 
-    def _use_legacy_prepared_statements(self):
+    def _use_legacy_prepared_statements(self) -> bool:
         if self.legacy_prepared_statements is not None:
             return self.legacy_prepared_statements
 
@@ -365,21 +376,21 @@ class DescribeOutput(NamedTuple):
     aliased: bool
 
     @classmethod
-    def from_row(cls, row: List[Any]):
+    def from_row(cls, row: List[Any]) -> DescribeOutput:
         return cls(*row)
 
 
 class ColumnDescription(NamedTuple):
     name: str
     type_code: int
-    display_size: int
-    internal_size: int
-    precision: int
-    scale: int
-    null_ok: bool
+    display_size: Optional[int]
+    internal_size: Optional[int]
+    precision: Optional[int]
+    scale: Optional[int]
+    null_ok: Optional[bool]
 
     @classmethod
-    def from_column(cls, column: Dict[str, Any]):
+    def from_column(cls, column: Dict[str, Any]) -> ColumnDescription:
         type_signature = column["typeSignature"]
         raw_type = type_signature["rawType"]
         arguments = type_signature["arguments"]
@@ -404,10 +415,10 @@ class Cursor:
 
     def __init__(
             self,
-            connection,
-            request,
+            connection: Connection,
+            request: trino.client.TrinoRequest,
             legacy_primitive_types: bool = False,
-            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
+            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> None:
         if not isinstance(connection, Connection):
             raise ValueError(
                 "connection must be a Connection object: {}".format(type(connection))
@@ -416,38 +427,42 @@ class Cursor:
         self._request = request
 
         self.arraysize = 1
-        self._iterator = None
-        self._query = None
+        self._iterator: Optional[Iterator[Any]] = None
+        self._query: Optional[trino.client.TrinoQuery] = None
         self._legacy_primitive_types = legacy_primitive_types
         self._stats_callback = stats_callback
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
+        if self._iterator is None:
+            raise trino.exceptions.ProgrammingError(
+                "no result set to iterate over: execute() has not been called yet"
+            )
         return self._iterator
 
-    def __enter__(self):
+    def __enter__(self) -> Cursor:
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.close()
 
     @property
-    def connection(self):
+    def connection(self) -> Connection:
         return self._connection
 
     @property
-    def info_uri(self):
+    def info_uri(self) -> Optional[str]:
         if self._query is not None:
             return self._query.info_uri
         return None
 
     @property
-    def update_type(self):
+    def update_type(self) -> Optional[str]:
         if self._query is not None:
             return self._query.update_type
         return None
 
     @property
-    def description(self) -> List[ColumnDescription]:
+    def description(self) -> Optional[List[ColumnDescription]]:
         if self._query is None or self._query.columns is None:
             return None
 
@@ -457,7 +472,7 @@ class Cursor:
         ]
 
     @property
-    def rowcount(self):
+    def rowcount(self) -> int:
         """The rowcount will be returned for INSERT, UPDATE, DELETE, MERGE
         and CTAS statements based on `update_count` returned by the Trino
         API.
@@ -475,7 +490,7 @@ class Cursor:
         return -1
 
     @property
-    def stats(self):
+    def stats(self) -> Optional[Dict[Any, Any]]:
         if self._query is not None:
             return self._query.stats
         return None
@@ -493,15 +508,15 @@ class Cursor:
         return None
 
     @property
-    def warnings(self):
+    def warnings(self) -> Optional[List[Dict[Any, Any]]]:
         if self._query is not None:
             return self._query.warnings
         return None
 
-    def setinputsizes(self, sizes):
+    def setinputsizes(self, sizes: Any) -> None:
         raise trino.exceptions.NotSupportedError
 
-    def setoutputsize(self, size, column):
+    def setoutputsize(self, size: Any, column: Any) -> None:
         raise trino.exceptions.NotSupportedError
 
     def _prepare_statement(self, statement: str, name: str) -> None:
@@ -519,9 +534,9 @@ class Cursor:
 
     def _execute_prepared_statement(
         self,
-        statement_name,
-        params
-    ):
+        statement_name: str,
+        params: Sequence[Any],
+    ) -> trino.client.TrinoQuery:
         sql = 'EXECUTE ' + statement_name + ' USING ' + ','.join(map(self._format_prepared_param, params))
         return trino.client.TrinoQuery(
             self._request,
@@ -529,7 +544,7 @@ class Cursor:
             legacy_primitive_types=self._legacy_primitive_types,
             stats_callback=self._stats_callback)
 
-    def _execute_immediate_statement(self, statement: str, params):
+    def _execute_immediate_statement(self, statement: str, params: Sequence[Any]) -> trino.client.TrinoQuery:
         """
         Binds parameters and executes a statement in one call.
 
@@ -544,7 +559,7 @@ class Cursor:
             legacy_primitive_types=self._legacy_primitive_types,
             stats_callback=self._stats_callback)
 
-    def _format_prepared_param(self, param):
+    def _format_prepared_param(self, param: Any) -> str:
         """
         Formats parameters to be passed in an
         EXECUTE statement.
@@ -632,15 +647,13 @@ class Cursor:
                                         legacy_primitive_types=self._legacy_primitive_types)
         query.execute()
 
-    def _generate_unique_statement_name(self):
+    def _generate_unique_statement_name(self) -> str:
         return 'st_' + uuid.uuid4().hex.replace('-', '')
 
-    def execute(self, operation, params=None):
+    def execute(self, operation: str, params: Optional[Sequence[Any]] = None) -> "Cursor":
         if params:
-            assert isinstance(params, (list, tuple)), (
-                'params must be a list or tuple containing the query '
-                'parameter values'
-            )
+            if not isinstance(params, (list, tuple)):
+                raise TypeError('params must be a list or tuple containing the query parameter values')
 
             if self.connection._use_legacy_prepared_statements():
                 statement_name = self._generate_unique_statement_name()
@@ -670,7 +683,7 @@ class Cursor:
             self._iterator = iter(self._query.execute())
         return self
 
-    def executemany(self, operation, seq_of_params):
+    def executemany(self, operation: str, seq_of_params: Sequence[Sequence[Any]]) -> "Cursor":
         """
         PEP-0249: Prepare a database operation (query or command) and then
         execute it against all parameter sequences or mappings found in the sequence seq_of_parameters.
@@ -689,7 +702,7 @@ class Cursor:
         for parameters in seq_of_params[:-1]:
             self.execute(operation, parameters)
             self.fetchall()
-            if self._query.update_type is None:
+            if self.update_type is None:
                 raise NotSupportedError("Query must return update type")
         if seq_of_params:
             self.execute(operation, seq_of_params[-1])
@@ -707,15 +720,19 @@ class Cursor:
         .execute*() did not produce any result set or no call was issued yet.
         """
 
+        if self._iterator is None:
+            raise trino.exceptions.ProgrammingError(
+                "no result set to fetch from: execute() has not been called yet"
+            )
+
         try:
-            assert self._iterator is not None
             return next(self._iterator)
         except StopIteration:
             return None
         except trino.exceptions.HttpError as err:
             raise trino.exceptions.OperationalError(str(err))
 
-    def fetchmany(self, size=None) -> List[List[Any]]:
+    def fetchmany(self, size: Optional[int] = None) -> List[List[Any]]:
         """
         PEP-0249: Fetch the next set of rows of a query result, returning a
         sequence of sequences (e.g. a list of tuples). An empty sequence is
@@ -763,18 +780,22 @@ class Cursor:
 
         return list(map(lambda x: DescribeOutput.from_row(x), result))
 
-    def genall(self):
+    def genall(self) -> Any:
+        if self._query is None:
+            raise trino.exceptions.ProgrammingError(
+                "no result set to iterate over: execute() has not been called yet"
+            )
         return self._query.result
 
     def fetchall(self) -> List[List[Any]]:
         return list(iter(self.fetchone, None))
 
-    def cancel(self):
+    def cancel(self) -> None:
         if self._query is None:
             return
         self._query.cancel()
 
-    def close(self):
+    def close(self) -> None:
         self.cancel()
         # TODO: Cancel not only the last query executed on this cursor
         #  but also any other outstanding queries executed through this cursor.
@@ -783,16 +804,16 @@ class Cursor:
 class SegmentCursor(Cursor):
     def __init__(
             self,
-            connection,
-            request,
+            connection: Connection,
+            request: trino.client.TrinoRequest,
             legacy_primitive_types: bool = False,
-            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
+            stats_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> None:
         super().__init__(
             connection, request, legacy_primitive_types=legacy_primitive_types, stats_callback=stats_callback)
         if self.connection._client_session.encoding is None:
             raise ValueError("SegmentCursor can only be used if encoding is set on the connection")
 
-    def execute(self, operation, params=None):
+    def execute(self, operation: str, params: Optional[Sequence[Any]] = None) -> "Cursor":
         if params:
             # TODO: refactor code to allow for params to be supported
             raise ValueError("params not supported")
@@ -812,11 +833,12 @@ DateFromTicks = datetime.date.fromtimestamp
 TimestampFromTicks = datetime.datetime.fromtimestamp
 
 
-def TimeFromTicks(ticks):
-    return datetime.time(*datetime.localtime(ticks)[3:6])
+def TimeFromTicks(ticks: float) -> datetime.time:
+    local = localtime(ticks)
+    return datetime.time(local.tm_hour, local.tm_min, local.tm_sec)
 
 
-def Binary(value):
+def Binary(value: Any) -> bytes:
     if isinstance(value, (bytes, bytearray, memoryview)):
         return bytes(value)
     if isinstance(value, str):
@@ -825,10 +847,10 @@ def Binary(value):
 
 
 class DBAPITypeObject:
-    def __init__(self, *values):
+    def __init__(self, *values: str) -> None:
         self.values = [v.lower() for v in values]
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return other.lower() in self.values
 
 

--- a/trino/types.py
+++ b/trino/types.py
@@ -6,7 +6,6 @@ from datetime import time
 from datetime import timedelta
 from decimal import Decimal
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import Generic
 from typing import List
@@ -100,7 +99,7 @@ class TimestampWithTimeZone(Timestamp, TemporalType[datetime]):
 class NamedRowTuple(Tuple[Any, ...]):
     """Custom tuple class as namedtuple doesn't support missing or duplicate names"""
     def __new__(cls, values: List[Any], names: List[str], types: List[str]) -> NamedRowTuple:
-        return cast(NamedRowTuple, super().__new__(cls, values))
+        return super().__new__(cls, values)
 
     def __init__(self, values: List[Any], names: List[Optional[str]], types: List[str]):
         self._names = names


### PR DESCRIPTION
Fix type annotations so that mypy can check trino.client and trino.dbapi without any type violations.

Behavioral changes:
* When called before cursor.execute():
  * iter(cursor) now raises ProgrammingError instead of TypeError: iter() returned non-iterator of type 'NoneType'
  * cursor.fetchone()/fetchmany()/fetchall() now raise ProgrammingError instead of AssertionError (TypeError with -O)
  * cursor.genall() now raises ProgrammingError instead of AttributeError
* TrinoRequest(max_attempts=n) with n < 1 now raises ValueError, instead of failing on first request with UnboundLocalError.

Fixes:
* trino.dbapi.TimeFromTicks() now works correctly, previously it tried to use undefined datetime.localtime
* TrinoUserError() can be formatted, previously str(error) raised AtttributeError

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #python-client in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
